### PR TITLE
Handle case-insensitive workflow names

### DIFF
--- a/TheBackend.DynamicModels/BusinessRuleService.cs
+++ b/TheBackend.DynamicModels/BusinessRuleService.cs
@@ -45,5 +45,15 @@ public class BusinessRuleService
         => _workflows.Any(w => w.WorkflowName.Equals(workflowName, StringComparison.OrdinalIgnoreCase));
 
     public ValueTask<List<RuleResultTree>> ExecuteAsync(string workflowName, params RuleParameter[] parameters)
-        => _engine.ExecuteAllRulesAsync(workflowName, parameters);
+    {
+        var workflow = _workflows.FirstOrDefault(w =>
+            w.WorkflowName.Equals(workflowName, StringComparison.OrdinalIgnoreCase));
+
+        if (workflow == null)
+        {
+            return ValueTask.FromResult(new List<RuleResultTree>());
+        }
+
+        return _engine.ExecuteAllRulesAsync(workflow.WorkflowName, parameters);
+    }
 }


### PR DESCRIPTION
## Summary
- ensure BusinessRuleService can run workflows regardless of case
- resolve workflow names against the list before execution

## Testing
- `dotnet format TheBackend.sln --no-restore`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`


------
https://chatgpt.com/codex/tasks/task_e_687e60ed95008324b85c6a02fb27f2d6