### PR TITLE
Add business rule execution test

### DIFF
--- a/TheBackend.DynamicModels/BusinessRuleService.cs
+++ b/TheBackend.DynamicModels/BusinessRuleService.cs
@@ -35,7 +35,8 @@ public class BusinessRuleService
 
     public void AddOrUpdateWorkflow(Workflow workflow)
     {
-        var existing = _workflows.FirstOrDefault(w => w.WorkflowName == workflow.WorkflowName);
+        var existing = _workflows.FirstOrDefault(
+            w => w.WorkflowName.Equals(workflow.WorkflowName, StringComparison.OrdinalIgnoreCase));
         if (existing != null) _workflows.Remove(existing);
         _workflows.Add(workflow);
         SaveWorkflows();
@@ -45,5 +46,10 @@ public class BusinessRuleService
         => _workflows.Any(w => w.WorkflowName.Equals(workflowName, StringComparison.OrdinalIgnoreCase));
 
     public ValueTask<List<RuleResultTree>> ExecuteAsync(string workflowName, params RuleParameter[] parameters)
-        => _engine.ExecuteAllRulesAsync(workflowName, parameters);
+    {
+        var actualName = _workflows
+            .FirstOrDefault(w => w.WorkflowName.Equals(workflowName, StringComparison.OrdinalIgnoreCase))
+            ?.WorkflowName ?? workflowName;
+        return _engine.ExecuteAllRulesAsync(actualName, parameters);
+    }
 }

--- a/TheBackend.Tests/BusinessRuleServiceTests.cs
+++ b/TheBackend.Tests/BusinessRuleServiceTests.cs
@@ -35,4 +35,33 @@ public class BusinessRuleServiceTests
             File.Delete(tempFile);
         }
     }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsSuccess()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            var service = new BusinessRuleService(tempFile);
+            var workflow = new Workflow
+            {
+                WorkflowName = "Order.Create",
+                Rules = new List<Rule>
+                {
+                    new Rule { RuleName = "AlwaysTrue", Expression = "true" }
+                }
+            };
+            service.AddOrUpdateWorkflow(workflow);
+
+            var obj = new { Id = 1 };
+            var results = await service.ExecuteAsync("order.Create", new RuleParameter("entity", obj));
+
+            Assert.Single(results);
+            Assert.True(results[0].IsSuccess);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- extend `BusinessRuleService` to locate workflows case-insensitively
- add test `ExecuteAsync_ReturnsSuccess` to verify saved workflow execution

## Testing
- `dotnet test TheBackend.sln --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687e60edf71c8324b2e0d84aba774d15