### PR TITLE
Add Blazor admin UI with Tailwind

### DIFF
--- a/TheBackend.Admin/App.razor
+++ b/TheBackend.Admin/App.razor
@@ -1,0 +1,12 @@
+﻿<Router AppAssembly="@typeof(App).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+        <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+    </Found>
+    <NotFound>
+        <PageTitle>Not found</PageTitle>
+        <LayoutView Layout="@typeof(MainLayout)">
+            <p role="alert">Sorry, there's nothing at this address.</p>
+        </LayoutView>
+    </NotFound>
+</Router>

--- a/TheBackend.Admin/Layout/MainLayout.razor
+++ b/TheBackend.Admin/Layout/MainLayout.razor
@@ -1,0 +1,7 @@
+@inherits LayoutComponentBase
+
+<NavMenu />
+
+<div class="p-4">
+    @Body
+</div>

--- a/TheBackend.Admin/Layout/NavMenu.razor
+++ b/TheBackend.Admin/Layout/NavMenu.razor
@@ -1,0 +1,10 @@
+<nav class="bg-gray-800 text-white p-4">
+    <ul class="flex space-x-4">
+        <li>
+            <NavLink href="" Match="NavLinkMatch.All">Home</NavLink>
+        </li>
+        <li>
+            <NavLink href="models">Models</NavLink>
+        </li>
+    </ul>
+</nav>

--- a/TheBackend.Admin/Pages/Home.razor
+++ b/TheBackend.Admin/Pages/Home.razor
@@ -1,0 +1,7 @@
+﻿@page "/"
+
+<PageTitle>Home</PageTitle>
+
+<h1 class="text-2xl font-bold mb-4">Admin UI</h1>
+
+<p>Use the navigation menu to interact with the API.</p>

--- a/TheBackend.Admin/Pages/Models.razor
+++ b/TheBackend.Admin/Pages/Models.razor
@@ -1,0 +1,43 @@
+@page "/models"
+@inject HttpClient Http
+
+<h1 class="text-2xl font-bold mb-4">Models</h1>
+
+@if (models == null)
+{
+    <p>Loading...</p>
+}
+else if (!models.Any())
+{
+    <p>No models defined.</p>
+}
+else
+{
+    <ul class="space-y-2">
+        @foreach (var model in models)
+        {
+            <li class="border p-2 rounded">@model.ModelName</li>
+        }
+    </ul>
+}
+
+@code {
+    private List<ModelDefinition>? models;
+
+    protected override async Task OnInitializedAsync()
+    {
+        models = await Http.GetFromJsonAsync<List<ModelDefinition>>("api/models");
+    }
+
+    public class ModelDefinition
+    {
+        public string? ModelName { get; set; }
+        public List<PropertyDefinition> Properties { get; set; } = new();
+    }
+
+    public class PropertyDefinition
+    {
+        public string? PropertyName { get; set; }
+        public string? PropertyType { get; set; }
+    }
+}

--- a/TheBackend.Admin/Program.cs
+++ b/TheBackend.Admin/Program.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using TheBackend.Admin;
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+builder.RootComponents.Add<App>("#app");
+builder.RootComponents.Add<HeadOutlet>("head::after");
+
+builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+
+await builder.Build().RunAsync();

--- a/TheBackend.Admin/Properties/launchSettings.json
+++ b/TheBackend.Admin/Properties/launchSettings.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
+      "applicationUrl": "http://localhost:5281",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/TheBackend.Admin/TheBackend.Admin.csproj
+++ b/TheBackend.Admin/TheBackend.Admin.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.7" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/TheBackend.Admin/_Imports.razor
+++ b/TheBackend.Admin/_Imports.razor
@@ -1,0 +1,10 @@
+﻿@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.AspNetCore.Components.WebAssembly.Http
+@using Microsoft.JSInterop
+@using TheBackend.Admin
+@using TheBackend.Admin.Layout

--- a/TheBackend.Admin/wwwroot/css/app.css
+++ b/TheBackend.Admin/wwwroot/css/app.css
@@ -1,0 +1,1 @@
+/* Custom CSS for the admin UI. Tailwind classes provide most styling. */

--- a/TheBackend.Admin/wwwroot/index.html
+++ b/TheBackend.Admin/wwwroot/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TheBackend.Admin</title>
+    <base href="/" />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="css/app.css" />
+</head>
+
+<body>
+    <div id="app">
+        <svg class="loading-progress">
+            <circle r="40%" cx="50%" cy="50%" />
+            <circle r="40%" cx="50%" cy="50%" />
+        </svg>
+        <div class="loading-progress-text"></div>
+    </div>
+
+    <div id="blazor-error-ui">
+        An unhandled error has occurred.
+        <a href="." class="reload">Reload</a>
+        <span class="dismiss">🗙</span>
+    </div>
+    <script src="_framework/blazor.webassembly.js"></script>
+</body>
+
+</html>

--- a/TheBackend.Api/Controllers/ModelsController.cs
+++ b/TheBackend.Api/Controllers/ModelsController.cs
@@ -16,6 +16,13 @@ namespace TheBackend.Api.Controllers
             _dbContextService = dbContextService;
         }
 
+        [HttpGet]
+        public IActionResult GetModels()
+        {
+            var models = _modelService.LoadModels();
+            return Ok(models);
+        }
+
         [HttpPost]
         public async Task<IActionResult> CreateOrUpdateModel([FromBody] ModelDefinition definition)
         {

--- a/TheBackend.sln
+++ b/TheBackend.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TheBackend.Api", "TheBacken
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TheBackend.DynamicModels", "TheBackend.DynamicModels\TheBackend.DynamicModels.csproj", "{5D223EF4-FECE-4D7F-9B61-76337E3387B5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TheBackend.Admin", "TheBackend.Admin\TheBackend.Admin.csproj", "{4F8B9237-517F-42D9-9FFC-7469A1188A40}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -97,6 +99,18 @@ Global
 		{5D223EF4-FECE-4D7F-9B61-76337E3387B5}.Release|x64.Build.0 = Release|Any CPU
 		{5D223EF4-FECE-4D7F-9B61-76337E3387B5}.Release|x86.ActiveCfg = Release|Any CPU
 		{5D223EF4-FECE-4D7F-9B61-76337E3387B5}.Release|x86.Build.0 = Release|Any CPU
+		{4F8B9237-517F-42D9-9FFC-7469A1188A40}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F8B9237-517F-42D9-9FFC-7469A1188A40}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4F8B9237-517F-42D9-9FFC-7469A1188A40}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4F8B9237-517F-42D9-9FFC-7469A1188A40}.Debug|x64.Build.0 = Debug|Any CPU
+		{4F8B9237-517F-42D9-9FFC-7469A1188A40}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4F8B9237-517F-42D9-9FFC-7469A1188A40}.Debug|x86.Build.0 = Debug|Any CPU
+		{4F8B9237-517F-42D9-9FFC-7469A1188A40}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4F8B9237-517F-42D9-9FFC-7469A1188A40}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4F8B9237-517F-42D9-9FFC-7469A1188A40}.Release|x64.ActiveCfg = Release|Any CPU
+		{4F8B9237-517F-42D9-9FFC-7469A1188A40}.Release|x64.Build.0 = Release|Any CPU
+		{4F8B9237-517F-42D9-9FFC-7469A1188A40}.Release|x86.ActiveCfg = Release|Any CPU
+		{4F8B9237-517F-42D9-9FFC-7469A1188A40}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add new `TheBackend.Admin` Blazor WebAssembly project with Tailwind CDN
- implement `/models` page to list model definitions
- simplify layout and navigation
- expose GET endpoint in `ModelsController`

## Testing
- `dotnet format TheBackend.sln`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`


------
https://chatgpt.com/codex/tasks/task_e_687e698e16f0832485799c1add1a52f9