### PR TITLE
Add ApiResponse wrapper and middleware

### DIFF
--- a/TheBackend.Api/ApiResponse.cs
+++ b/TheBackend.Api/ApiResponse.cs
@@ -1,0 +1,45 @@
+namespace TheBackend.Api;
+
+public class ApiResponse<T>
+{
+    public bool Success { get; set; }
+    public string Message { get; set; } = "Request successful";
+    public T? Data { get; set; }
+    public List<ValidationError>? Errors { get; set; }
+    public MetaInfo Meta { get; set; } = new();
+
+    public static ApiResponse<T> Ok(T data, string? message = null)
+    {
+        return new ApiResponse<T>
+        {
+            Success = true,
+            Message = message ?? "Request successful",
+            Data = data
+        };
+    }
+
+    public static ApiResponse<T> Fail(string message, List<ValidationError>? errors = null)
+    {
+        return new ApiResponse<T>
+        {
+            Success = false,
+            Message = message,
+            Errors = errors
+        };
+    }
+}
+
+public class ValidationError
+{
+    public string Field { get; set; } = string.Empty;
+    public string Error { get; set; } = string.Empty;
+}
+
+public class MetaInfo
+{
+    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+    public string? CorrelationId { get; set; }
+    public string? TraceId { get; set; }
+    public int? StatusCode { get; set; }
+    public string ApiVersion { get; set; } = "v1";
+}

--- a/TheBackend.Api/Controllers/ModelsController.cs
+++ b/TheBackend.Api/Controllers/ModelsController.cs
@@ -1,5 +1,6 @@
 ﻿using TheBackend.DynamicModels;
 using Microsoft.AspNetCore.Mvc;
+using TheBackend.Api;
 
 namespace TheBackend.Api.Controllers
 {
@@ -28,7 +29,7 @@ namespace TheBackend.Api.Controllers
             // Regenerate DbContext, apply migration
             await _dbContextService.RegenerateAndMigrateAsync();
 
-            return Ok($"Model {definition.ModelName} created/updated and migrated.");
+            return Ok(ApiResponse<string>.Ok($"Model {definition.ModelName} created/updated and migrated."));
         }
     }
 }

--- a/TheBackend.Api/Controllers/RulesController.cs
+++ b/TheBackend.Api/Controllers/RulesController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using RulesEngine.Models;
 using TheBackend.DynamicModels;
+using TheBackend.Api;
 
 namespace TheBackend.Api.Controllers;
 
@@ -16,20 +17,22 @@ public class RulesController : ControllerBase
     }
 
     [HttpGet]
-    public IActionResult GetAll() => Ok(_ruleService.GetWorkflows());
+    public IActionResult GetAll() => Ok(ApiResponse<object>.Ok(_ruleService.GetWorkflows()));
 
     [HttpGet("{workflowName}")]
     public IActionResult Get(string workflowName)
     {
         var wf = _ruleService.GetWorkflows()
             .FirstOrDefault(w => w.WorkflowName.Equals(workflowName, StringComparison.OrdinalIgnoreCase));
-        return wf == null ? NotFound() : Ok(wf);
+        return wf == null
+            ? NotFound(ApiResponse<object>.Fail("Workflow not found"))
+            : Ok(ApiResponse<object>.Ok(wf!));
     }
 
     [HttpPost]
     public IActionResult CreateOrUpdate([FromBody] Workflow workflow)
     {
         _ruleService.AddOrUpdateWorkflow(workflow);
-        return Ok();
+        return Ok(ApiResponse<string>.Ok("Workflow saved"));
     }
 }

--- a/TheBackend.Api/Program.cs
+++ b/TheBackend.Api/Program.cs
@@ -1,4 +1,7 @@
 using TheBackend.DynamicModels;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using TheBackend.Api;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
@@ -9,6 +12,25 @@ builder.Services.AddSingleton<BusinessRuleService>();
 var app = builder.Build();
 var dbService = app.Services.GetRequiredService<DynamicDbContextService>();
 await dbService.RegenerateAndMigrateAsync();
+
+app.Use(async (context, next) =>
+{
+    try
+    {
+        await next();
+    }
+    catch (Exception ex)
+    {
+        var logger = context.RequestServices.GetRequiredService<ILogger<Program>>();
+        logger.LogError(ex, "Unhandled exception");
+
+        var response = ApiResponse<object>.Fail("An unexpected error occurred.");
+        response.Meta.TraceId = context.TraceIdentifier;
+        response.Meta.StatusCode = StatusCodes.Status500InternalServerError;
+        context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+        await context.Response.WriteAsJsonAsync(response);
+    }
+});
 
 app.MapControllers();
 app.Run();


### PR DESCRIPTION
## Summary
- implement `ApiResponse<T>` with metadata
- add error-handling middleware
- update controllers to return `ApiResponse` objects
- adjust models controller and rules controller

## Testing
- `dotnet format TheBackend.sln --verbosity diagnostic`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`

------
https://chatgpt.com/codex/tasks/task_e_687e693475908324a54821c6f1d8e381