### PR TITLE
Update admin UI for ApiResponse

### DIFF
--- a/TheBackend.Admin/Pages/Models.razor
+++ b/TheBackend.Admin/Pages/Models.razor
@@ -1,5 +1,6 @@
 @page "/models"
-@inject HttpClient Http
+@inject ApiClient Api
+@using TheBackend.DynamicModels
 
 <h1 class="text-2xl font-bold mb-4">Models</h1>
 
@@ -26,18 +27,6 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        models = await Http.GetFromJsonAsync<List<ModelDefinition>>("api/models");
-    }
-
-    public class ModelDefinition
-    {
-        public string? ModelName { get; set; }
-        public List<PropertyDefinition> Properties { get; set; } = new();
-    }
-
-    public class PropertyDefinition
-    {
-        public string? PropertyName { get; set; }
-        public string? PropertyType { get; set; }
+        models = await Api.GetAsync<List<ModelDefinition>>("api/models");
     }
 }

--- a/TheBackend.Admin/Program.cs
+++ b/TheBackend.Admin/Program.cs
@@ -1,11 +1,13 @@
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using TheBackend.Admin;
+using TheBackend.Admin.Shared;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
-builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri("https://localhost:7020/") });
+builder.Services.AddScoped<ApiClient>();
 
 await builder.Build().RunAsync();

--- a/TheBackend.Admin/Shared/ApiClient.cs
+++ b/TheBackend.Admin/Shared/ApiClient.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+using TheBackend.Admin.Shared;
+
+namespace TheBackend.Admin.Shared;
+
+public class ApiClient
+{
+    private readonly HttpClient _http;
+
+    public ApiClient(HttpClient http)
+    {
+        _http = http;
+    }
+
+    public async Task<T?> GetAsync<T>(string uri) where T : class
+    {
+        var json = await _http.GetStringAsync(uri);
+        return DeserializeData<T>(json);
+    }
+
+    private static T? DeserializeData<T>(string json) where T : class
+    {
+        try
+        {
+            var api = JsonSerializer.Deserialize<ApiResponse<T>>(json);
+            if (api?.Data != null) return api.Data;
+        }
+        catch
+        {
+        }
+
+        return JsonSerializer.Deserialize<T>(json);
+    }
+}

--- a/TheBackend.Admin/Shared/ApiResponse.cs
+++ b/TheBackend.Admin/Shared/ApiResponse.cs
@@ -1,0 +1,25 @@
+namespace TheBackend.Admin.Shared;
+
+public class ApiResponse<T>
+{
+    public bool Success { get; set; }
+    public string Message { get; set; } = "Request successful";
+    public T? Data { get; set; }
+    public List<ValidationError>? Errors { get; set; }
+    public MetaInfo Meta { get; set; } = new();
+}
+
+public class ValidationError
+{
+    public string Field { get; set; } = string.Empty;
+    public string Error { get; set; } = string.Empty;
+}
+
+public class MetaInfo
+{
+    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+    public string? CorrelationId { get; set; }
+    public string? TraceId { get; set; }
+    public int? StatusCode { get; set; }
+    public string ApiVersion { get; set; } = "v1";
+}

--- a/TheBackend.Admin/TheBackend.Admin.csproj
+++ b/TheBackend.Admin/TheBackend.Admin.csproj
@@ -11,4 +11,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.7" PrivateAssets="all" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\TheBackend.DynamicModels\TheBackend.DynamicModels.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/TheBackend.Admin/_Imports.razor
+++ b/TheBackend.Admin/_Imports.razor
@@ -8,3 +8,5 @@
 @using Microsoft.JSInterop
 @using TheBackend.Admin
 @using TheBackend.Admin.Layout
+@using TheBackend.Admin.Shared
+@using TheBackend.DynamicModels


### PR DESCRIPTION
## Summary
- hook up admin UI to API using a shared `ApiClient`
- reuse model definitions from the DynamicModels project
- set `HttpClient` base address to the API endpoint

## Testing
- `dotnet format TheBackend.sln` *(fails: required references did not load)*
- `dotnet build TheBackend.sln -c Release` *(fails: NETSDK1082 runtime pack for browser-wasm)*
- `dotnet test TheBackend.sln`

------
https://chatgpt.com/codex/tasks/task_e_687e6d1e9e38832486f0f8778b974fca