### PR TITLE
Add repository-wide EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+max_line_length = 120


### PR DESCRIPTION
## Summary
- introduce `.editorconfig` to enforce 4-space indentation and 120 character lines for all C# files

## Testing
- `dotnet format TheBackend.sln`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`


------
https://chatgpt.com/codex/tasks/task_e_687e70aa23b08324970eddbe4afcbfca