### PR TITLE
Switch to async file operations

### DIFF
--- a/TheBackend.Api/Controllers/ModelsController.cs
+++ b/TheBackend.Api/Controllers/ModelsController.cs
@@ -1,6 +1,7 @@
 ﻿using TheBackend.DynamicModels;
 using Microsoft.AspNetCore.Mvc;
 using TheBackend.Api;
+using System.Threading.Tasks;
 
 namespace TheBackend.Api.Controllers
 {
@@ -18,20 +19,20 @@ namespace TheBackend.Api.Controllers
         }
 
         [HttpGet]
-        public IActionResult GetModels()
+        public async Task<IActionResult> GetModels()
         {
-            var models = _modelService.LoadModels();
+            var models = await _modelService.LoadModelsAsync();
             return Ok(models);
         }
 
         [HttpPost]
         public async Task<IActionResult> CreateOrUpdateModel([FromBody] ModelDefinition definition)
         {
-            var models = _modelService.LoadModels();
+            var models = await _modelService.LoadModelsAsync();
             var existing = models.FirstOrDefault(m => m.ModelName == definition.ModelName);
             if (existing != null) models.Remove(existing);
             models.Add(definition);
-            _modelService.SaveModels(models);
+            await _modelService.SaveModelsAsync(models);
 
             // Regenerate DbContext, apply migration
             await _dbContextService.RegenerateAndMigrateAsync();

--- a/TheBackend.Api/Controllers/RulesController.cs
+++ b/TheBackend.Api/Controllers/RulesController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using RulesEngine.Models;
 using TheBackend.DynamicModels;
 using TheBackend.Api;
+using System.Threading.Tasks;
 
 namespace TheBackend.Api.Controllers;
 
@@ -30,9 +31,9 @@ public class RulesController : ControllerBase
     }
 
     [HttpPost]
-    public IActionResult CreateOrUpdate([FromBody] Workflow workflow)
+    public async Task<IActionResult> CreateOrUpdate([FromBody] Workflow workflow)
     {
-        _ruleService.AddOrUpdateWorkflow(workflow);
+        await _ruleService.AddOrUpdateWorkflowAsync(workflow);
         return Ok(ApiResponse<string>.Ok("Workflow saved"));
     }
 }

--- a/TheBackend.DynamicModels/BusinessRuleService.cs
+++ b/TheBackend.DynamicModels/BusinessRuleService.cs
@@ -1,6 +1,8 @@
 using Newtonsoft.Json;
 using RulesEngine.Models;
 using RulesEngine;
+using System.IO;
+using System.Threading.Tasks;
 
 namespace TheBackend.DynamicModels;
 
@@ -13,33 +15,33 @@ public class BusinessRuleService
     public BusinessRuleService(string? rulesFile = null)
     {
         _rulesFile = rulesFile ?? "rules.json";
-        _workflows = LoadWorkflows(_rulesFile);
+        _workflows = LoadWorkflowsAsync(_rulesFile).GetAwaiter().GetResult();
         _engine = new RulesEngine.RulesEngine(_workflows.ToArray());
     }
 
-    private static List<Workflow> LoadWorkflows(string file)
+    private static async Task<List<Workflow>> LoadWorkflowsAsync(string file)
     {
         if (!File.Exists(file)) return new List<Workflow>();
-        var json = File.ReadAllText(file);
+        var json = await File.ReadAllTextAsync(file);
         return JsonConvert.DeserializeObject<List<Workflow>>(json) ?? new List<Workflow>();
     }
 
-    private void SaveWorkflows()
+    private async Task SaveWorkflowsAsync()
     {
         var json = JsonConvert.SerializeObject(_workflows, Formatting.Indented);
-        File.WriteAllText(_rulesFile, json);
+        await File.WriteAllTextAsync(_rulesFile, json);
         _engine = new RulesEngine.RulesEngine(_workflows.ToArray());
     }
 
     public List<Workflow> GetWorkflows() => _workflows;
 
-    public void AddOrUpdateWorkflow(Workflow workflow)
+    public async Task AddOrUpdateWorkflowAsync(Workflow workflow)
     {
         var existing = _workflows.FirstOrDefault(
             w => w.WorkflowName.Equals(workflow.WorkflowName, StringComparison.OrdinalIgnoreCase));
         if (existing != null) _workflows.Remove(existing);
         _workflows.Add(workflow);
-        SaveWorkflows();
+        await SaveWorkflowsAsync();
     }
 
     public bool HasWorkflow(string workflowName)

--- a/TheBackend.DynamicModels/ModelDefinitionService.cs
+++ b/TheBackend.DynamicModels/ModelDefinitionService.cs
@@ -4,6 +4,7 @@
     using Newtonsoft.Json;
     using System.Collections.Generic;
     using System.IO;
+    using System.Threading.Tasks;
 
     public class ModelDefinition
     {
@@ -25,30 +26,30 @@
         private const string ModelsFile = "models.json";
         private const string MigrationFilesFile = "migrations.json";
 
-        public List<ModelDefinition> LoadModels()
+        public async Task<List<ModelDefinition>> LoadModelsAsync()
         {
             if (!File.Exists(ModelsFile)) return new List<ModelDefinition>();
-            var json = File.ReadAllText(ModelsFile);
+            var json = await File.ReadAllTextAsync(ModelsFile);
             return JsonConvert.DeserializeObject<List<ModelDefinition>>(json);
         }
 
-        public void SaveModels(List<ModelDefinition> models)
+        public async Task SaveModelsAsync(List<ModelDefinition> models)
         {
             var json = JsonConvert.SerializeObject(models, Formatting.Indented);
-            File.WriteAllText(ModelsFile, json);
+            await File.WriteAllTextAsync(ModelsFile, json);
         }
 
-        public Dictionary<string, string>? LoadMigrationFiles()
+        public async Task<Dictionary<string, string>?> LoadMigrationFilesAsync()
         {
             if (!File.Exists(MigrationFilesFile)) return null;
-            var json = File.ReadAllText(MigrationFilesFile);
+            var json = await File.ReadAllTextAsync(MigrationFilesFile);
             return JsonConvert.DeserializeObject<Dictionary<string, string>>(json);
         }
 
-        public void SaveMigrationFiles(Dictionary<string, string> migrationFiles)
+        public async Task SaveMigrationFilesAsync(Dictionary<string, string> migrationFiles)
         {
             var json = JsonConvert.SerializeObject(migrationFiles, Formatting.Indented);
-            File.WriteAllText(MigrationFilesFile, json);
+            await File.WriteAllTextAsync(MigrationFilesFile, json);
         }
     }
 }

--- a/TheBackend.Tests/BusinessRuleServiceTests.cs
+++ b/TheBackend.Tests/BusinessRuleServiceTests.cs
@@ -5,13 +5,14 @@ using System.IO;
 using TheBackend.DynamicModels;
 using Xunit;
 using Rule = RulesEngine.Models.Rule;
+using System.Threading.Tasks;
 
 namespace TheBackend.Tests;
 
 public class BusinessRuleServiceTests
 {
     [Fact]
-    public void AddOrUpdateWorkflow_PersistsWorkflow()
+    public async Task AddOrUpdateWorkflow_PersistsWorkflow()
     {
         var tempFile = Path.GetTempFileName();
         try
@@ -25,7 +26,7 @@ public class BusinessRuleServiceTests
                     new Rule { RuleName = "AlwaysTrue", Expression = "true" }
                 }
             };
-            service.AddOrUpdateWorkflow(workflow);
+            await service.AddOrUpdateWorkflowAsync(workflow);
 
             var serviceReloaded = new BusinessRuleService(tempFile);
             Assert.True(serviceReloaded.HasWorkflow("TestWorkflow"));
@@ -51,7 +52,7 @@ public class BusinessRuleServiceTests
                     new Rule { RuleName = "AlwaysTrue", Expression = "true" }
                 }
             };
-            service.AddOrUpdateWorkflow(workflow);
+            await service.AddOrUpdateWorkflowAsync(workflow);
 
             var obj = new { Id = 1 };
             var results = await service.ExecuteAsync("order.Create", new RuleParameter("entity", obj));

--- a/TheBackend.Tests/ModelDefinitionServiceTests.cs
+++ b/TheBackend.Tests/ModelDefinitionServiceTests.cs
@@ -1,12 +1,13 @@
 ﻿using TheBackend.DynamicModels;
 using Xunit;
 
+using System.Threading.Tasks;
 namespace TheBackend.Tests;
 
 public class ModelDefinitionServiceTests
 {
     [Fact]
-    public void SaveAndLoadModels()
+    public async Task SaveAndLoadModels()
     {
         var originalDir = Directory.GetCurrentDirectory();
         var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -23,8 +24,8 @@ public class ModelDefinitionServiceTests
                     Properties = new List<PropertyDefinition>()
                 }
             };
-            service.SaveModels(models);
-            var loaded = service.LoadModels();
+            await service.SaveModelsAsync(models);
+            var loaded = await service.LoadModelsAsync();
             Assert.Single(loaded);
             Assert.Equal("Sample", loaded[0].ModelName);
         }


### PR DESCRIPTION
## Summary
- use `File.ReadAllTextAsync`/`File.WriteAllTextAsync`
- update model definition service and consumers to be async
- allow rules to save and load asynchronously
- regenerate context files using async I/O

## Testing
- `dotnet format TheBackend.sln --no-restore --verbosity minimal`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`

------
https://chatgpt.com/codex/tasks/task_e_687e70cd66f083249b19ee056488eaec