### PR TITLE
Use DI for generic repository

### DIFF
--- a/TheBackend.Api/Controllers/GenericController.cs
+++ b/TheBackend.Api/Controllers/GenericController.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json;
 using TheBackend.Application.Repositories;
 using TheBackend.DynamicModels;
 using TheBackend.Infrastructure.Repositories;
+using Microsoft.Extensions.DependencyInjection;
 using RulesEngine.Models;
 using System.Linq;
 using TheBackend.Api;
@@ -16,11 +17,13 @@ namespace TheBackend.Api.Controllers
     {
         private readonly DynamicDbContextService _dbContextService;
         private readonly BusinessRuleService _ruleService;
+        private readonly IServiceProvider _serviceProvider;
 
-        public GenericController(DynamicDbContextService dbContextService, BusinessRuleService ruleService)
+        public GenericController(DynamicDbContextService dbContextService, BusinessRuleService ruleService, IServiceProvider serviceProvider)
         {
             _dbContextService = dbContextService;
             _ruleService = ruleService;
+            _serviceProvider = serviceProvider;
         }
 
         [HttpGet]
@@ -30,7 +33,7 @@ namespace TheBackend.Api.Controllers
             if (modelType == null) return NotFound(ApiResponse<object>.Fail("Model not found"));
 
             var repoType = typeof(IGenericRepository<>).MakeGenericType(modelType);
-            var repo = Activator.CreateInstance(typeof(GenericRepository<>).MakeGenericType(modelType), _dbContextService.GetDbContext());
+            var repo = _serviceProvider.GetRequiredService(repoType);
 
             var getAllMethod = repoType.GetMethod("GetAllAsync");
             var resultTask = (Task)getAllMethod.Invoke(repo, null);
@@ -65,7 +68,7 @@ namespace TheBackend.Api.Controllers
             }
 
             var repoType = typeof(IGenericRepository<>).MakeGenericType(modelType);
-            var repo = Activator.CreateInstance(typeof(GenericRepository<>).MakeGenericType(modelType), dbContext);
+            var repo = _serviceProvider.GetRequiredService(repoType);
 
             var getMethod = repoType.GetMethod("GetByIdAsync");
             var resultTask = (Task)getMethod.Invoke(repo, new[] { convertedId });
@@ -109,7 +112,7 @@ namespace TheBackend.Api.Controllers
             }
 
             var repoType = typeof(IGenericRepository<>).MakeGenericType(modelType);
-            var repo = Activator.CreateInstance(typeof(GenericRepository<>).MakeGenericType(modelType), dbContext);
+            var repo = _serviceProvider.GetRequiredService(repoType);
 
             var addMethod = repoType.GetMethod("AddAsync");
             var task = (Task)addMethod.Invoke(repo, new[] { entity });
@@ -168,7 +171,7 @@ namespace TheBackend.Api.Controllers
             }
 
             var repoType = typeof(IGenericRepository<>).MakeGenericType(modelType);
-            var repo = Activator.CreateInstance(typeof(GenericRepository<>).MakeGenericType(modelType), dbContext);
+            var repo = _serviceProvider.GetRequiredService(repoType);
 
             var updateMethod = repoType.GetMethod("UpdateAsync");
             var task = (Task)updateMethod.Invoke(repo, new[] { entity });
@@ -207,7 +210,7 @@ namespace TheBackend.Api.Controllers
             }
 
             var repoType = typeof(IGenericRepository<>).MakeGenericType(modelType);
-            var repo = Activator.CreateInstance(typeof(GenericRepository<>).MakeGenericType(modelType), dbContext);
+            var repo = _serviceProvider.GetRequiredService(repoType);
 
             var deleteMethod = repoType.GetMethod("DeleteAsync");
             var task = (Task)deleteMethod.Invoke(repo, new[] { convertedId });

--- a/TheBackend.Api/Program.cs
+++ b/TheBackend.Api/Program.cs
@@ -1,6 +1,10 @@
 using TheBackend.DynamicModels;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using TheBackend.Application.Repositories;
+using TheBackend.Infrastructure.Repositories;
 using TheBackend.Api;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -8,6 +12,12 @@ builder.Services.AddControllers();
 builder.Services.AddSingleton<ModelDefinitionService>();
 builder.Services.AddSingleton<DynamicDbContextService>();
 builder.Services.AddSingleton<BusinessRuleService>();
+builder.Services.AddScoped<DbContext>(provider =>
+{
+    var dbService = provider.GetRequiredService<DynamicDbContextService>();
+    return dbService.GetDbContext();
+});
+builder.Services.AddScoped(typeof(IGenericRepository<>), typeof(GenericRepository<>));
 
 var app = builder.Build();
 var dbService = app.Services.GetRequiredService<DynamicDbContextService>();


### PR DESCRIPTION
## Summary
- register open generic repository services
- inject `IServiceProvider` into `GenericController`
- resolve repository instances via DI instead of `Activator.CreateInstance`

## Testing
- `dotnet format DynamicModelApi.sln` *(fails: solution file not found)*
- `dotnet build DynamicModelApi.sln -c Release` *(fails: solution file not found)*
- `dotnet test DynamicModelApi.sln` *(fails: solution file not found)*
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`

------
https://chatgpt.com/codex/tasks/task_e_687e70d2eac88324821b20e117e04e1f