### PR TITLE
Add data page and vertical nav

### DIFF
--- a/TheBackend.Admin/Layout/MainLayout.razor
+++ b/TheBackend.Admin/Layout/MainLayout.razor
@@ -1,8 +1,8 @@
 @inherits LayoutComponentBase
 
-<div class="min-h-screen bg-gray-100">
+<div class="min-h-screen bg-gray-100 flex">
     <NavMenu />
-    <div class="p-4 container mx-auto">
+    <div class="p-4 flex-1 overflow-auto">
         @Body
     </div>
 </div>

--- a/TheBackend.Admin/Layout/NavMenu.razor
+++ b/TheBackend.Admin/Layout/NavMenu.razor
@@ -1,10 +1,13 @@
-<nav class="bg-gray-800 text-white p-4 shadow">
-    <ul class="flex space-x-4">
+<nav class="bg-gray-800 text-white w-48 min-h-screen p-4 shadow">
+    <ul class="space-y-2">
         <li>
-            <NavLink class="hover:text-gray-300 px-3 py-2 rounded" href="" Match="NavLinkMatch.All">Home</NavLink>
+            <NavLink class="block hover:bg-gray-700 px-3 py-2 rounded" href="" Match="NavLinkMatch.All">Home</NavLink>
         </li>
         <li>
-            <NavLink class="hover:text-gray-300 px-3 py-2 rounded" href="models">Models</NavLink>
+            <NavLink class="block hover:bg-gray-700 px-3 py-2 rounded" href="models">Models</NavLink>
+        </li>
+        <li>
+            <NavLink class="block hover:bg-gray-700 px-3 py-2 rounded" href="data">Data</NavLink>
         </li>
     </ul>
 </nav>

--- a/TheBackend.Admin/Pages/Data.razor
+++ b/TheBackend.Admin/Pages/Data.razor
@@ -1,0 +1,166 @@
+@page "/data"
+@inject HttpClient Http
+
+<h1 class="text-3xl font-bold mb-4">Data</h1>
+
+@if (models == null)
+{
+    <p>Loading...</p>
+}
+else
+{
+    <div class="mb-4">
+        <label class="block text-sm font-medium mb-1">Select Model</label>
+        <select class="border rounded p-2" value="@selectedModel" @onchange="OnModelChanged">
+            <option value="">-- choose --</option>
+            @foreach (var m in models)
+            {
+                <option value="@m.ModelName">@m.ModelName</option>
+            }
+        </select>
+    </div>
+
+    if (selectedDefinition != null && records != null)
+    {
+        <div class="mb-2">
+            <button class="bg-blue-500 text-white px-4 py-2 rounded" @onclick="NewRecord">Add Record</button>
+        </div>
+        <table class="min-w-full bg-white shadow rounded border">
+            <thead class="bg-gray-50 border-b">
+                <tr>
+                    @foreach (var p in selectedDefinition.Properties)
+                    {
+                        <th class="text-left px-3 py-2 font-semibold">@p.Name</th>
+                    }
+                    <th class="px-3 py-2"></th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var row in records)
+                {
+                    <tr class="border-b hover:bg-gray-50">
+                        @foreach (var p in selectedDefinition.Properties)
+                        {
+                            <td class="px-3 py-2">@row[p.Name]</td>
+                        }
+                        <td class="px-3 py-2 text-right space-x-2">
+                            <button class="text-blue-600" @onclick="() => EditRecord(row)">Edit</button>
+                            <button class="text-red-600" @onclick="() => DeleteRecord(row)">Delete</button>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    }
+}
+
+@if (editingRecord != null)
+{
+    <div class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+        <div class="bg-white p-6 rounded shadow-lg w-full max-w-lg">
+            <h2 class="text-xl font-bold mb-4">@recordTitle</h2>
+            <EditForm OnValidSubmit="SaveRecord">
+                @foreach (var p in selectedDefinition!.Properties)
+                {
+                    <div class="mb-2">
+                        <label class="block text-sm font-medium mb-1">@p.Name</label>
+                        <InputText class="border rounded w-full p-2"
+                                   value="@editingRecord[p.Name]?.ToString()"
+                                   @onchange="(e => editingRecord[p.Name] = e.Value?.ToString() ?? string.Empty)" />
+                    </div>
+                }
+                <div class="flex justify-end space-x-2 mt-4">
+                    <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Save</button>
+                    <button type="button" class="bg-gray-300 px-4 py-2 rounded" @onclick="CancelEdit">Cancel</button>
+                </div>
+            </EditForm>
+        </div>
+    </div>
+}
+
+@code {
+    private List<ModelDefinition>? models;
+    private string? selectedModel;
+    private ModelDefinition? selectedDefinition;
+    private List<Dictionary<string, object>>? records;
+    private Dictionary<string, object>? editingRecord;
+    private string recordTitle = string.Empty;
+
+    protected override async Task OnInitializedAsync()
+    {
+        models = await Http.GetFromJsonAsync<List<ModelDefinition>>("api/models");
+    }
+
+    private async Task OnModelChanged(ChangeEventArgs e)
+    {
+        selectedModel = e.Value?.ToString();
+        await LoadRecords();
+    }
+
+    private async Task LoadRecords()
+    {
+        if (string.IsNullOrEmpty(selectedModel))
+        {
+            selectedDefinition = null;
+            records = null;
+            return;
+        }
+
+        selectedDefinition = models!.First(m => m.ModelName == selectedModel);
+        var json = await Http.GetStringAsync($"api/{selectedModel}");
+        var doc = JsonDocument.Parse(json);
+        records = doc.RootElement.EnumerateArray()
+            .Select(e => e.EnumerateObject().ToDictionary(p => p.Name, p => (object?)p.Value.ToString() ?? string.Empty))
+            .ToList();
+    }
+
+    private void NewRecord()
+    {
+        editingRecord = selectedDefinition!.Properties.ToDictionary(p => p.Name, p => (object?)string.Empty);
+        recordTitle = $"Add {selectedModel}";
+    }
+
+    private void EditRecord(Dictionary<string, object> row)
+    {
+        editingRecord = new Dictionary<string, object>(row);
+        recordTitle = $"Edit {selectedModel}";
+    }
+
+    private void CancelEdit()
+    {
+        editingRecord = null;
+    }
+
+    private async Task SaveRecord()
+    {
+        if (editingRecord == null || selectedDefinition == null || string.IsNullOrEmpty(selectedModel))
+            return;
+
+        var keyProp = selectedDefinition.Properties.FirstOrDefault(p => p.IsKey);
+        var json = JsonSerializer.Serialize(editingRecord);
+        if (keyProp != null && records!.Any(r => r[keyProp.Name]?.ToString() == editingRecord[keyProp.Name]?.ToString()))
+        {
+            await Http.PutAsync($"api/{selectedModel}/{editingRecord[keyProp.Name]}", new StringContent(json, Encoding.UTF8, "application/json"));
+        }
+        else
+        {
+            await Http.PostAsync($"api/{selectedModel}", new StringContent(json, Encoding.UTF8, "application/json"));
+        }
+
+        await LoadRecords();
+        editingRecord = null;
+    }
+
+    private async Task DeleteRecord(Dictionary<string, object> row)
+    {
+        if (selectedDefinition == null || string.IsNullOrEmpty(selectedModel))
+            return;
+
+        var keyProp = selectedDefinition.Properties.FirstOrDefault(p => p.IsKey);
+        if (keyProp == null)
+            return;
+
+        await Http.DeleteAsync($"api/{selectedModel}/{row[keyProp.Name]}");
+        await LoadRecords();
+    }
+}

--- a/TheBackend.Admin/Pages/Models.razor
+++ b/TheBackend.Admin/Pages/Models.razor
@@ -20,23 +20,28 @@ else
     }
     else
     {
-        <ul class="space-y-2">
+        <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
             @foreach (var model in models)
             {
-                <li class="border p-4 rounded bg-white shadow flex justify-between items-center">
-                    <div>
+                <div class="bg-white rounded border shadow">
+                    <div class="bg-gray-50 border-b px-4 py-2 flex justify-between items-center">
                         <h3 class="font-semibold">@model.ModelName</h3>
-                        <ul class="text-sm list-disc list-inside">
+                        <button class="text-blue-600 hover:underline" @onclick="() => EditModel(model)">Edit</button>
+                    </div>
+                    <table class="w-full text-sm">
+                        <tbody>
                             @foreach (var prop in model.Properties)
                             {
-                                <li>@prop.Name (@prop.Type)</li>
+                                <tr>
+                                    <td class="px-4 py-1 font-medium">@prop.Name</td>
+                                    <td class="px-4 py-1 text-right">@prop.Type</td>
+                                </tr>
                             }
-                        </ul>
-                    </div>
-                    <button class="text-blue-600 hover:underline" @onclick="() => EditModel(model)">Edit</button>
-                </li>
+                        </tbody>
+                    </table>
+                </div>
             }
-        </ul>
+        </div>
     }
 }
 

--- a/TheBackend.Admin/_Imports.razor
+++ b/TheBackend.Admin/_Imports.razor
@@ -11,3 +11,5 @@
 @using TheBackend.Admin.Shared
 @using TheBackend.Domain.Models
 @using System.Linq
+@using System.Text.Json
+@using System.Text

--- a/TheBackend.DynamicModels/DynamicDbContext.cs
+++ b/TheBackend.DynamicModels/DynamicDbContext.cs
@@ -4,10 +4,10 @@ namespace TheBackend.DynamicModels
     public class DynamicDbContext : DbContext
     {
         public DynamicDbContext(DbContextOptions<DynamicDbContext> options) : base(options) { }
-      
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-       
+
         }
     }
 }


### PR DESCRIPTION
## Summary
- switch layout to vertical navigation
- redesign model cards to look more like DB tables
- add `Data` page to manage records with CRUD operations
- include helper usings

## Testing
- `dotnet format TheBackend.sln --no-restore`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`


------
https://chatgpt.com/codex/tasks/task_e_687ec0802e6883248f51cbe44f4a1288