### PR TITLE
Use Material theme for admin UI

### DIFF
--- a/TheBackend.Admin/Layout/MainLayout.razor
+++ b/TheBackend.Admin/Layout/MainLayout.razor
@@ -1,8 +1,8 @@
 @inherits LayoutComponentBase
 
-<div class="min-h-screen bg-gray-100 flex">
+<div class="app-layout">
     <NavMenu />
-    <div class="p-4 flex-1 overflow-auto">
+    <div class="app-content">
         @Body
     </div>
 </div>

--- a/TheBackend.Admin/Layout/NavMenu.razor
+++ b/TheBackend.Admin/Layout/NavMenu.razor
@@ -1,13 +1,25 @@
-<nav class="bg-gray-800 text-white w-48 min-h-screen p-4 shadow">
-    <ul class="space-y-2">
+<nav class="nav-menu">
+    <div class="logo">
+        <img src="https://source.unsplash.com/random/64x64?logo" alt="Logo" />
+    </div>
+    <ul>
         <li>
-            <NavLink class="block hover:bg-gray-700 px-3 py-2 rounded" href="" Match="NavLinkMatch.All">Home</NavLink>
+            <NavLink class="" href="" Match="NavLinkMatch.All">
+                <span class="material-icons">home</span>
+                Home
+            </NavLink>
         </li>
         <li>
-            <NavLink class="block hover:bg-gray-700 px-3 py-2 rounded" href="models">Models</NavLink>
+            <NavLink href="models">
+                <span class="material-icons">list</span>
+                Models
+            </NavLink>
         </li>
         <li>
-            <NavLink class="block hover:bg-gray-700 px-3 py-2 rounded" href="data">Data</NavLink>
+            <NavLink href="data">
+                <span class="material-icons">table_chart</span>
+                Data
+            </NavLink>
         </li>
     </ul>
 </nav>

--- a/TheBackend.Admin/Pages/Data.razor
+++ b/TheBackend.Admin/Pages/Data.razor
@@ -1,7 +1,7 @@
 @page "/data"
 @inject HttpClient Http
 
-<h1 class="text-3xl font-bold mb-4">Data</h1>
+<h1 class="mdl-typography--headline4">Data</h1>
 
 @if (models == null)
 {
@@ -10,22 +10,24 @@
 else
 {
     <div class="mb-4">
-        <label class="block text-sm font-medium mb-1">Select Model</label>
-        <select class="border rounded p-2" value="@selectedModel" @onchange="OnModelChanged">
+        <label>Select Model</label>
+        <div class="mdl-textfield mdl-js-textfield">
+            <select class="mdl-textfield__input" value="@selectedModel" @onchange="OnModelChanged">
             <option value="">-- choose --</option>
             @foreach (var m in models)
             {
                 <option value="@m.ModelName">@m.ModelName</option>
             }
-        </select>
+            </select>
+        </div>
     </div>
 
     if (selectedDefinition != null && records != null)
     {
         <div class="mb-2">
-            <button class="bg-blue-500 text-white px-4 py-2 rounded" @onclick="NewRecord">Add Record</button>
+            <button class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored" @onclick="NewRecord">Add Record</button>
         </div>
-        <table class="min-w-full bg-white shadow rounded border">
+        <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
             <thead class="bg-gray-50 border-b">
                 <tr>
                     @foreach (var p in selectedDefinition.Properties)
@@ -38,14 +40,14 @@ else
             <tbody>
                 @foreach (var row in records)
                 {
-                    <tr class="border-b hover:bg-gray-50">
+                    <tr>
                         @foreach (var p in selectedDefinition.Properties)
                         {
                             <td class="px-3 py-2">@row[p.Name]</td>
                         }
-                        <td class="px-3 py-2 text-right space-x-2">
-                            <button class="text-blue-600" @onclick="() => EditRecord(row)">Edit</button>
-                            <button class="text-red-600" @onclick="() => DeleteRecord(row)">Delete</button>
+                        <td class="text-right">
+                            <button class="mdl-button mdl-js-button" @onclick="() => EditRecord(row)">Edit</button>
+                            <button class="mdl-button mdl-js-button" @onclick="() => DeleteRecord(row)">Delete</button>
                         </td>
                     </tr>
                 }
@@ -56,22 +58,22 @@ else
 
 @if (editingRecord != null)
 {
-    <div class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
-        <div class="bg-white p-6 rounded shadow-lg w-full max-w-lg">
+    <div class="overlay">
+        <div class="modal">
             <h2 class="text-xl font-bold mb-4">@recordTitle</h2>
             <EditForm OnValidSubmit="SaveRecord">
                 @foreach (var p in selectedDefinition!.Properties)
                 {
-                    <div class="mb-2">
-                        <label class="block text-sm font-medium mb-1">@p.Name</label>
-                        <InputText class="border rounded w-full p-2"
+                    <div class="mdl-textfield mdl-js-textfield">
+                        <InputText class="mdl-textfield__input"
                                    value="@editingRecord[p.Name]?.ToString()"
                                    @onchange="(e => editingRecord[p.Name] = e.Value?.ToString() ?? string.Empty)" />
+                        <label class="mdl-textfield__label">@p.Name</label>
                     </div>
                 }
-                <div class="flex justify-end space-x-2 mt-4">
-                    <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Save</button>
-                    <button type="button" class="bg-gray-300 px-4 py-2 rounded" @onclick="CancelEdit">Cancel</button>
+                <div class="mt-4" style="text-align:right;">
+                    <button type="submit" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored">Save</button>
+                    <button type="button" class="mdl-button mdl-js-button" @onclick="CancelEdit">Cancel</button>
                 </div>
             </EditForm>
         </div>

--- a/TheBackend.Admin/Pages/Home.razor
+++ b/TheBackend.Admin/Pages/Home.razor
@@ -2,6 +2,6 @@
 
 <PageTitle>Home</PageTitle>
 
-<h1 class="text-2xl font-bold mb-4">Admin UI</h1>
+<h1 class="mdl-typography--headline4">Admin UI</h1>
 
 <p>Use the navigation menu to interact with the API.</p>

--- a/TheBackend.Admin/Pages/Models.razor
+++ b/TheBackend.Admin/Pages/Models.razor
@@ -2,10 +2,10 @@
 @inject ApiClient Api
 @using TheBackend.Domain.Models
 
-<h1 class="text-3xl font-bold mb-4">Models</h1>
+<h1 class="mdl-typography--headline4">Models</h1>
 
 <div class="mb-4">
-    <button class="bg-blue-500 text-white px-4 py-2 rounded" @onclick="NewModel">Add Model</button>
+    <button class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored" @onclick="NewModel">Add Model</button>
 </div>
 
 @if (models == null)
@@ -23,10 +23,10 @@ else
         <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
             @foreach (var model in models)
             {
-                <div class="bg-white rounded border shadow">
-                    <div class="bg-gray-50 border-b px-4 py-2 flex justify-between items-center">
-                        <h3 class="font-semibold">@model.ModelName</h3>
-                        <button class="text-blue-600 hover:underline" @onclick="() => EditModel(model)">Edit</button>
+                <div class="mdl-card mdl-shadow--2dp">
+                    <div class="mdl-card__title">
+                        <h3 class="mdl-card__title-text">@model.ModelName</h3>
+                        <button class="mdl-button mdl-js-button" @onclick="() => EditModel(model)">Edit</button>
                     </div>
                     <table class="w-full text-sm">
                         <tbody>
@@ -47,36 +47,48 @@ else
 
 @if (editingModel != null)
 {
-    <div class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
-        <div class="bg-white p-6 rounded shadow-lg w-full max-w-2xl">
+    <div class="overlay">
+        <div class="modal">
             <h2 class="text-xl font-bold mb-4">@formTitle</h2>
             <EditForm Model="editingModel" OnValidSubmit="SaveModel">
-                <div class="mb-4">
-                    <label class="block text-sm font-medium mb-1">Model Name</label>
-                    <InputText class="border rounded w-full p-2" @bind-Value="editingModel.ModelName" />
+                <div class="mdl-textfield mdl-js-textfield">
+                    <InputText class="mdl-textfield__input" @bind-Value="editingModel.ModelName" />
+                    <label class="mdl-textfield__label">Model Name</label>
                 </div>
                 <h3 class="font-semibold mb-2">Properties</h3>
                 @foreach (var prop in editingModel.Properties)
                 {
-                    <div class="grid grid-cols-6 gap-2 mb-2 items-center">
-                        <InputText class="border rounded p-2" placeholder="Name" @bind-Value="prop.Name" />
-                        <InputText class="border rounded p-2" placeholder="Type" @bind-Value="prop.Type" />
-                        <div class="flex items-center">
-                            <InputCheckbox class="mr-1" @bind-Value="prop.IsKey" />
-                            <span class="text-sm">Key</span>
+                    <div class="mdl-grid" style="align-items:center;">
+                        <div class="mdl-cell mdl-cell--2-col">
+                            <InputText class="mdl-textfield__input" placeholder="Name" @bind-Value="prop.Name" />
                         </div>
-                        <div class="flex items-center">
-                            <InputCheckbox class="mr-1" @bind-Value="prop.IsRequired" />
-                            <span class="text-sm">Required</span>
+                        <div class="mdl-cell mdl-cell--2-col">
+                            <InputText class="mdl-textfield__input" placeholder="Type" @bind-Value="prop.Type" />
                         </div>
-                        <InputNumber class="border rounded p-2" placeholder="MaxLength" @bind-Value="prop.MaxLength" />
-                        <button type="button" class="text-red-600" @onclick="() => RemoveProperty(prop)">Remove</button>
+                        <div class="mdl-cell mdl-cell--2-col">
+                            <label class="mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect">
+                                <InputCheckbox class="mdl-checkbox__input" @bind-Value="prop.IsKey" />
+                                <span class="mdl-checkbox__label">Key</span>
+                            </label>
+                        </div>
+                        <div class="mdl-cell mdl-cell--2-col">
+                            <label class="mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect">
+                                <InputCheckbox class="mdl-checkbox__input" @bind-Value="prop.IsRequired" />
+                                <span class="mdl-checkbox__label">Required</span>
+                            </label>
+                        </div>
+                        <div class="mdl-cell mdl-cell--2-col">
+                            <InputNumber class="mdl-textfield__input" placeholder="Max Length" @bind-Value="prop.MaxLength" />
+                        </div>
+                        <div class="mdl-cell mdl-cell--2-col">
+                            <button type="button" class="mdl-button mdl-js-button" @onclick="() => RemoveProperty(prop)">Remove</button>
+                        </div>
                     </div>
                 }
-                <button type="button" class="bg-green-500 text-white px-2 py-1 rounded mb-4" @onclick="AddProperty">Add Property</button>
-                <div class="flex justify-end space-x-2">
-                    <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Save</button>
-                    <button type="button" class="bg-gray-300 px-4 py-2 rounded" @onclick="CancelEdit">Cancel</button>
+                <button type="button" class="mdl-button mdl-js-button mdl-button--raised" @onclick="AddProperty">Add Property</button>
+                <div class="mt-4" style="text-align:right;">
+                    <button type="submit" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored">Save</button>
+                    <button type="button" class="mdl-button mdl-js-button" @onclick="CancelEdit">Cancel</button>
                 </div>
             </EditForm>
         </div>

--- a/TheBackend.Admin/wwwroot/css/app.css
+++ b/TheBackend.Admin/wwwroot/css/app.css
@@ -1,1 +1,69 @@
-/* Custom CSS for the admin UI. Tailwind classes provide most styling. */
+/* Basic styling when using Material Design Lite */
+body.app-body {
+    background-color: #f5f5f5;
+    font-family: 'Roboto', sans-serif;
+}
+
+.app-layout {
+    display: flex;
+    min-height: 100vh;
+}
+
+.app-content {
+    flex: 1;
+    padding: 16px;
+    overflow: auto;
+}
+
+.nav-menu {
+    width: 240px;
+    min-height: 100vh;
+    background-color: #37474F;
+    color: #fff;
+    padding: 16px;
+}
+
+.nav-menu a {
+    color: #fff;
+    display: flex;
+    align-items: center;
+    padding: 8px;
+    border-radius: 4px;
+    text-decoration: none;
+}
+
+.nav-menu a.active,
+.nav-menu a:hover {
+    background-color: #455A64;
+}
+
+.nav-menu .logo {
+    text-align: center;
+    margin-bottom: 16px;
+}
+
+.nav-menu .logo img {
+    border-radius: 50%;
+}
+
+.nav-menu a .material-icons {
+    margin-right: 8px;
+}
+
+.overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.modal {
+    background: #fff;
+    padding: 24px;
+    border-radius: 4px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    width: 100%;
+    max-width: 600px;
+}

--- a/TheBackend.Admin/wwwroot/index.html
+++ b/TheBackend.Admin/wwwroot/index.html
@@ -6,11 +6,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>TheBackend.Admin</title>
     <base href="/" />
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+    <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css" />
+    <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
     <link rel="stylesheet" href="css/app.css" />
 </head>
 
-<body class="bg-gray-100">
+<body class="app-body">
     <div id="app">
         <svg class="loading-progress">
             <circle r="40%" cx="50%" cy="50%" />


### PR DESCRIPTION
## Summary
- switch index page to use Material Design Lite CDN
- add Material styles and components
- create nav menu with icons and a logo
- update data and model pages for improved forms
- style layout with Material-inspired CSS

## Testing
- `dotnet format TheBackend.sln`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`


------
https://chatgpt.com/codex/tasks/task_e_687ec8866abc83249d1d2c6b650f1d7b