### PR TITLE
Add contextual sidebar and floating add button

### DIFF
--- a/TheBackend.Admin/Layout/MainLayout.razor
+++ b/TheBackend.Admin/Layout/MainLayout.razor
@@ -1,8 +1,26 @@
 @inherits LayoutComponentBase
 
-<div class="app-layout">
-    <NavMenu />
-    <div class="app-content">
-        @Body
+<CascadingValue Value="this">
+    <div class="app-layout">
+        <NavMenu />
+        <div class="app-content">
+            @Body
+        </div>
+        @if (RightSidebarContent != null)
+        {
+            <div class="right-sidebar">
+                @RightSidebarContent
+            </div>
+        }
     </div>
-</div>
+</CascadingValue>
+
+@code {
+    private RenderFragment? RightSidebarContent { get; set; }
+
+    public void SetRightSidebar(RenderFragment? content)
+    {
+        RightSidebarContent = content;
+        StateHasChanged();
+    }
+}

--- a/TheBackend.Admin/Pages/Data.razor
+++ b/TheBackend.Admin/Pages/Data.razor
@@ -1,5 +1,7 @@
 @page "/data"
 @inject HttpClient Http
+@using TheBackend.Admin.Shared
+@implements IDisposable
 
 <h1 class="h3">Data</h1>
 
@@ -20,11 +22,15 @@ else
         </select>
     </div>
 
-    if (selectedDefinition != null && records != null)
+    if (selectedDefinition != null && records != null && !records.Any())
     {
-        <div class="mb-2">
-            <button class="btn btn-primary" @onclick="NewRecord">Add Record</button>
+        <div class="text-center my-5">
+            <p>No items.</p>
+            <button class="btn btn-primary" @onclick="NewRecord">Create Item</button>
         </div>
+    }
+    else if (selectedDefinition != null && records != null)
+    {
         <table class="table table-striped">
             <thead class="table-light">
                 <tr>
@@ -51,6 +57,9 @@ else
                 }
             </tbody>
         </table>
+        <div class="fab">
+            <button class="btn btn-success" @onclick="NewRecord"><i class="bi bi-plus"></i></button>
+        </div>
     }
 }
 
@@ -79,6 +88,9 @@ else
 }
 
 @code {
+    [CascadingParameter]
+    public MainLayout? Layout { get; set; }
+
     private List<ModelDefinition>? models;
     private string? selectedModel;
     private ModelDefinition? selectedDefinition;
@@ -103,6 +115,7 @@ else
         {
             selectedDefinition = null;
             records = null;
+            Layout?.SetRightSidebar(null);
             return;
         }
 
@@ -112,6 +125,8 @@ else
         records = doc.RootElement.EnumerateArray()
             .Select(e => e.EnumerateObject().ToDictionary(p => p.Name, p => (object?)p.Value.ToString() ?? string.Empty))
             .ToList();
+
+        Layout?.SetRightSidebar(@<RightSidebar Definition="selectedDefinition" />);
     }
 
     private void NewRecord()
@@ -162,5 +177,10 @@ else
 
         await Http.DeleteAsync($"api/{selectedModel}/{row[keyProp.Name]}");
         await LoadRecords();
+    }
+
+    public void Dispose()
+    {
+        Layout?.SetRightSidebar(null);
     }
 }

--- a/TheBackend.Admin/Shared/RightSidebar.razor
+++ b/TheBackend.Admin/Shared/RightSidebar.razor
@@ -1,0 +1,18 @@
+@using TheBackend.Domain.Models
+@inherits LayoutComponentBase
+
+@if (Definition != null)
+{
+    <h5 class="mb-3">@Definition.ModelName</h5>
+    <ul class="list-unstyled">
+        @foreach (var p in Definition.Properties)
+        {
+            <li><i class="bi bi-circle-fill text-secondary"></i> @p.Name (@p.Type)</li>
+        }
+    </ul>
+}
+
+@code {
+    [Parameter]
+    public ModelDefinition? Definition { get; set; }
+}

--- a/TheBackend.Admin/wwwroot/css/app.css
+++ b/TheBackend.Admin/wwwroot/css/app.css
@@ -15,6 +15,14 @@ body.app-body {
     overflow: auto;
 }
 
+.right-sidebar {
+    width: 300px;
+    padding: 16px;
+    border-left: 1px solid #ddd;
+    background-color: #f8f9fa;
+    overflow-y: auto;
+}
+
 .nav-menu {
     width: 240px;
     min-height: 100vh;
@@ -66,4 +74,19 @@ body.app-body {
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
     width: 100%;
     max-width: 600px;
+}
+
+.fab {
+    position: fixed;
+    right: 24px;
+    bottom: 24px;
+    z-index: 1000;
+}
+
+.fab .btn {
+    border-radius: 50%;
+    width: 56px;
+    height: 56px;
+    font-size: 24px;
+    padding: 0;
 }


### PR DESCRIPTION
## Summary
- add `RightSidebar` component to display model metadata
- update `MainLayout` to host optional right sidebar
- enhance `Data` page with sidebar, no-items state, and floating add button
- extend admin styles for sidebar and floating action button

## Testing
- `dotnet format TheBackend.sln -v diagnostic`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`

------
https://chatgpt.com/codex/tasks/task_e_687ecf8e497c8324b112148d6e46a37a