### PR TITLE
Add basic dynamic collection admin UI

### DIFF
--- a/TheBackend.Admin/Components/ContextSidebar.razor
+++ b/TheBackend.Admin/Components/ContextSidebar.razor
@@ -1,0 +1,16 @@
+@inherits LayoutComponentBase
+
+@if (Definition != null)
+{
+    <h5 class="mb-3">@Definition.ModelName</h5>
+    <ul class="list-unstyled">
+        @foreach (var p in Definition.Properties)
+        {
+            <li><i class="bi bi-circle-fill text-secondary"></i> @p.Name (@p.Type)</li>
+        }
+    </ul>
+}
+
+@code {
+    [Parameter] public ModelDefinition? Definition { get; set; }
+}

--- a/TheBackend.Admin/Components/EmptyState.razor
+++ b/TheBackend.Admin/Components/EmptyState.razor
@@ -1,0 +1,9 @@
+@code {
+    [Parameter] public string Message { get; set; } = string.Empty;
+    [Parameter] public EventCallback OnCreate { get; set; }
+}
+
+<div class="text-center my-5">
+    <p>@Message</p>
+    <button class="btn btn-primary" @onclick="OnCreate">Create Item</button>
+</div>

--- a/TheBackend.Admin/Components/RecordTable.razor
+++ b/TheBackend.Admin/Components/RecordTable.razor
@@ -1,0 +1,33 @@
+@code {
+    [Parameter] public ModelDefinition Definition { get; set; } = new();
+    [Parameter] public List<Dictionary<string, object>> Records { get; set; } = new();
+    [Parameter] public EventCallback<Dictionary<string, object>> OnEdit { get; set; }
+    [Parameter] public EventCallback<Dictionary<string, object>> OnDelete { get; set; }
+}
+
+<table class="table table-striped">
+    <thead class="table-light">
+        <tr>
+            @foreach (var p in Definition.Properties)
+            {
+                <th class="text-start">@p.Name</th>
+            }
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var row in Records)
+        {
+            <tr>
+                @foreach (var p in Definition.Properties)
+                {
+                    <td>@row[p.Name]</td>
+                }
+                <td class="text-end">
+                    <button class="btn btn-sm btn-outline-secondary me-2" @onclick="() => OnEdit.InvokeAsync(row)">Edit</button>
+                    <button class="btn btn-sm btn-outline-danger" @onclick="() => OnDelete.InvokeAsync(row)">Delete</button>
+                </td>
+            </tr>
+        }
+    </tbody>
+</table>

--- a/TheBackend.Admin/Layout/NavMenu.razor
+++ b/TheBackend.Admin/Layout/NavMenu.razor
@@ -21,5 +21,42 @@
                 Data
             </NavLink>
         </li>
+        <li class="nav-item mb-2">
+            <button class="btn btn-sm text-light w-100 text-start" @onclick="ToggleCollections">
+                <i class="bi bi-collection"></i>
+                Collections
+            </button>
+            @if (showCollections && collections != null)
+            {
+                <ul class="nav flex-column ms-3 mt-1">
+                    @foreach (var c in collections)
+                    {
+                        <li class="nav-item mb-1">
+                            <NavLink class="nav-link text-light" href="@($"/collections/{c.ModelName}")">
+                                <i class="bi bi-folder"></i>
+                                @c.ModelName
+                            </NavLink>
+                        </li>
+                    }
+                </ul>
+            }
+        </li>
     </ul>
 </nav>
+
+@code {
+    [Inject] private ApiClient Api { get; set; } = default!;
+
+    private List<ModelDefinition>? collections;
+    private bool showCollections;
+
+    protected override async Task OnInitializedAsync()
+    {
+        collections = await Api.GetAsync<List<ModelDefinition>>("api/models");
+    }
+
+    private void ToggleCollections()
+    {
+        showCollections = !showCollections;
+    }
+}

--- a/TheBackend.Admin/Pages/CollectionView.razor
+++ b/TheBackend.Admin/Pages/CollectionView.razor
@@ -1,0 +1,118 @@
+@page "/collections/{CollectionName}"
+@inject CollectionService Collections
+@implements IDisposable
+
+@if (definition == null)
+{
+    <p class="text-center">Loading...</p>
+}
+else if (records != null && !records.Any())
+{
+    <EmptyState Message="No items found." OnCreate="NewRecord" />
+}
+else if (records != null)
+{
+    <RecordTable Definition="definition" Records="records" OnEdit="EditRecord" OnDelete="DeleteRecord" />
+    <div class="fab">
+        <button class="btn btn-success" @onclick="NewRecord">
+            <i class="bi bi-plus"></i>
+        </button>
+    </div>
+}
+
+@if (editingRecord != null)
+{
+    <div class="overlay">
+        <div class="modal">
+            <h2 class="text-xl font-bold mb-4">@modalTitle</h2>
+            <EditForm OnValidSubmit="SaveRecord">
+                @foreach (var p in definition!.Properties)
+                {
+                    <div class="mb-3">
+                        <label class="form-label">@p.Name</label>
+                        <InputText class="form-control"
+                                   value="@GetValue(p.Name)"
+                                   @onchange="e => editingRecord[p.Name] = e.Value?.ToString() ?? string.Empty" />
+                    </div>
+                }
+                <div class="mt-4 text-end">
+                    <button type="submit" class="btn btn-primary me-2">Save</button>
+                    <button type="button" class="btn btn-secondary" @onclick="CancelEdit">Cancel</button>
+                </div>
+            </EditForm>
+        </div>
+    </div>
+}
+
+@code {
+    [CascadingParameter] public MainLayout? Layout { get; set; }
+    [Parameter] public string CollectionName { get; set; } = string.Empty;
+
+    private ModelDefinition? definition;
+    private List<Dictionary<string, object>>? records;
+    private Dictionary<string, object>? editingRecord;
+    private string modalTitle = string.Empty;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        definition = await Collections.GetDefinitionAsync(CollectionName);
+        if (definition != null)
+        {
+            records = await Collections.GetRecordsAsync(CollectionName);
+            Layout?.SetRightSidebar(@<ContextSidebar Definition="definition" />);
+        }
+    }
+
+    private void NewRecord()
+    {
+        editingRecord = definition!.Properties.ToDictionary(p => p.Name, _ => (object)string.Empty);
+        modalTitle = $"Add {CollectionName}";
+    }
+
+    private void EditRecord(Dictionary<string, object> row)
+    {
+        editingRecord = new Dictionary<string, object>(row);
+        modalTitle = $"Edit {CollectionName}";
+    }
+
+    private void CancelEdit()
+    {
+        editingRecord = null;
+    }
+
+    private async Task SaveRecord()
+    {
+        if (editingRecord == null || definition == null)
+            return;
+
+        var key = definition.Properties.FirstOrDefault(p => p.IsKey);
+        if (key != null && records!.Any(r => r[key.Name]?.ToString() == editingRecord[key.Name]?.ToString()))
+        {
+            await Collections.UpdateAsync(CollectionName, editingRecord[key.Name]!, editingRecord);
+        }
+        else
+        {
+            await Collections.CreateAsync(CollectionName, editingRecord);
+        }
+
+        records = await Collections.GetRecordsAsync(CollectionName);
+        editingRecord = null;
+    }
+
+    private async Task DeleteRecord(Dictionary<string, object> row)
+    {
+        var key = definition?.Properties.FirstOrDefault(p => p.IsKey);
+        if (key == null) return;
+        await Collections.DeleteAsync(CollectionName, row[key.Name]!);
+        records = await Collections.GetRecordsAsync(CollectionName);
+    }
+
+    private string GetValue(string key) => editingRecord != null && editingRecord.TryGetValue(key, out var value)
+        ? value?.ToString() ?? string.Empty
+        : string.Empty;
+
+    public void Dispose()
+    {
+        Layout?.SetRightSidebar(null);
+    }
+}

--- a/TheBackend.Admin/Pages/Data.razor
+++ b/TheBackend.Admin/Pages/Data.razor
@@ -126,7 +126,7 @@ else
             .Select(e => e.EnumerateObject().ToDictionary(p => p.Name, p => (object?)p.Value.ToString() ?? string.Empty))
             .ToList();
 
-        Layout?.SetRightSidebar(@<RightSidebar Definition="selectedDefinition" />);
+        Layout?.SetRightSidebar(@<ContextSidebar Definition="selectedDefinition" />);
     }
 
     private void NewRecord()

--- a/TheBackend.Admin/Program.cs
+++ b/TheBackend.Admin/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using TheBackend.Admin;
 using TheBackend.Admin.Shared;
+using TheBackend.Admin.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
@@ -9,5 +10,6 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri("https://localhost:7020/") });
 builder.Services.AddScoped<ApiClient>();
+builder.Services.AddScoped<CollectionService>();
 
 await builder.Build().RunAsync();

--- a/TheBackend.Admin/Services/CollectionService.cs
+++ b/TheBackend.Admin/Services/CollectionService.cs
@@ -1,0 +1,55 @@
+using System.Text;
+using System.Text.Json;
+using TheBackend.Domain.Models;
+using TheBackend.Admin.Shared;
+
+namespace TheBackend.Admin.Services;
+
+public class CollectionService
+{
+    private readonly HttpClient _http;
+    private readonly ApiClient _api;
+
+    public CollectionService(HttpClient http, ApiClient api)
+    {
+        _http = http;
+        _api = api;
+    }
+
+    public async Task<List<ModelDefinition>> GetDefinitionsAsync()
+    {
+        return await _api.GetAsync<List<ModelDefinition>>("api/models") ?? new();
+    }
+
+    public async Task<ModelDefinition?> GetDefinitionAsync(string name)
+    {
+        var defs = await GetDefinitionsAsync();
+        return defs.FirstOrDefault(m => m.ModelName.Equals(name, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public async Task<List<Dictionary<string, object>>> GetRecordsAsync(string name)
+    {
+        var json = await _http.GetStringAsync($"api/{name}");
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.EnumerateArray()
+            .Select(e => e.EnumerateObject().ToDictionary(p => p.Name, p => (object)p.Value.ToString()))
+            .ToList();
+    }
+
+    public async Task CreateAsync(string name, Dictionary<string, object> record)
+    {
+        var json = JsonSerializer.Serialize(record);
+        await _http.PostAsync($"api/{name}", new StringContent(json, Encoding.UTF8, "application/json"));
+    }
+
+    public async Task UpdateAsync(string name, object id, Dictionary<string, object> record)
+    {
+        var json = JsonSerializer.Serialize(record);
+        await _http.PutAsync($"api/{name}/{id}", new StringContent(json, Encoding.UTF8, "application/json"));
+    }
+
+    public async Task DeleteAsync(string name, object id)
+    {
+        await _http.DeleteAsync($"api/{name}/{id}");
+    }
+}

--- a/TheBackend.Admin/_Imports.razor
+++ b/TheBackend.Admin/_Imports.razor
@@ -9,6 +9,8 @@
 @using TheBackend.Admin
 @using TheBackend.Admin.Layout
 @using TheBackend.Admin.Shared
+@using TheBackend.Admin.Services
+@using TheBackend.Admin.Components
 @using TheBackend.Domain.Models
 @using System.Linq
 @using System.Text.Json


### PR DESCRIPTION
## Summary
- implement new Blazor components for dynamic admin interface
- list collections in side nav and allow navigation to `/collections/{name}`
- provide `RecordTable`, `EmptyState` and `ContextSidebar` components
- add `CollectionView` page with CRUD actions for records
- register `CollectionService` in blazor app

## Testing
- `dotnet format TheBackend.sln --no-restore --verbosity diagnostic`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`


------
https://chatgpt.com/codex/tasks/task_e_687ed6ac06c883249b8dacfc51896fca