### PR TITLE
Add Blazor admin UI skeleton

### DIFF
--- a/TheBackend.Admin/Components/ContentHeader.razor
+++ b/TheBackend.Admin/Components/ContentHeader.razor
@@ -1,0 +1,14 @@
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="h4 m-0">@Title</h1>
+    <button class="btn btn-success" @onclick="OnCreate">
+        <i class="bi bi-plus"></i> Create
+    </button>
+</div>
+
+@code {
+    [Parameter]
+    public string Title { get; set; } = string.Empty;
+
+    [Parameter]
+    public EventCallback OnCreate { get; set; }
+}

--- a/TheBackend.Admin/Components/ContextSidebar.razor
+++ b/TheBackend.Admin/Components/ContextSidebar.razor
@@ -1,0 +1,8 @@
+<div class="right-sidebar">
+    <h5 class="mb-3">Tools</h5>
+    <ul class="list-unstyled">
+        <li>Layout</li>
+        <li>Import/Export</li>
+        <li>Flows</li>
+    </ul>
+</div>

--- a/TheBackend.Admin/Components/EmptyState.razor
+++ b/TheBackend.Admin/Components/EmptyState.razor
@@ -1,0 +1,12 @@
+<div class="text-center my-5">
+    <p>@Message</p>
+    <button class="btn btn-primary" @onclick="OnCreate">Create Item</button>
+</div>
+
+@code {
+    [Parameter]
+    public string Message { get; set; } = "No items.";
+
+    [Parameter]
+    public EventCallback OnCreate { get; set; }
+}

--- a/TheBackend.Admin/Components/RecordTable.razor
+++ b/TheBackend.Admin/Components/RecordTable.razor
@@ -1,0 +1,43 @@
+@if (Definition == null || Records == null)
+{
+    <p>Loading...</p>
+}
+else if (!Records.Any())
+{
+    <EmptyState Message="No records found" OnCreate="OnCreate" />
+}
+else
+{
+    <table class="table table-striped">
+        <thead class="table-light">
+            <tr>
+                @foreach (var p in Definition.Properties)
+                {
+                    <th class="text-start">@p.Name</th>
+                }
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var row in Records)
+            {
+                <tr>
+                    @foreach (var p in Definition.Properties)
+                    {
+                        <td>@row[p.Name]</td>
+                    }
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+@code {
+    [Parameter]
+    public TheBackend.Admin.Services.DynamicCollection? Definition { get; set; }
+
+    [Parameter]
+    public List<Dictionary<string, object>>? Records { get; set; }
+
+    [Parameter]
+    public EventCallback OnCreate { get; set; }
+}

--- a/TheBackend.Admin/Components/SidebarNav.razor
+++ b/TheBackend.Admin/Components/SidebarNav.razor
@@ -1,0 +1,33 @@
+@inject TheBackend.Admin.Services.CollectionService CollectionService
+
+@if (collections == null)
+{
+    <p>Loading...</p>
+}
+else
+{
+    <nav class="nav-menu bg-dark text-light p-3">
+        <div class="logo mb-3 text-center">
+            <img src="https://source.unsplash.com/random/64x64?logo" alt="Logo" />
+        </div>
+        <ul class="nav flex-column">
+            @foreach (var c in collections)
+            {
+                <li class="nav-item mb-2">
+                    <NavLink class="nav-link text-light" href="@($"/collections/{c.ModelName}")">
+                        @c.ModelName
+                    </NavLink>
+                </li>
+            }
+        </ul>
+    </nav>
+}
+
+@code {
+    private List<TheBackend.Admin.Services.DynamicCollection>? collections;
+
+    protected override async Task OnInitializedAsync()
+    {
+        collections = await CollectionService.GetCollectionsAsync();
+    }
+}

--- a/TheBackend.Admin/Layout/MainLayout.razor
+++ b/TheBackend.Admin/Layout/MainLayout.razor
@@ -2,16 +2,11 @@
 
 <CascadingValue Value="this">
     <div class="app-layout">
-        <NavMenu />
+        <SidebarNav />
         <div class="app-content">
             @Body
         </div>
-        @if (RightSidebarContent != null)
-        {
-            <div class="right-sidebar">
-                @RightSidebarContent
-            </div>
-        }
+        <ContextSidebar />
     </div>
 </CascadingValue>
 

--- a/TheBackend.Admin/Pages/CollectionView.razor
+++ b/TheBackend.Admin/Pages/CollectionView.razor
@@ -1,0 +1,26 @@
+@page "/collections/{CollectionName}"
+@inject TheBackend.Admin.Services.CollectionService CollectionService
+@inject NavigationManager NavigationManager
+
+<ContentHeader Title="@CollectionName" OnCreate="NewRecord" />
+
+<RecordTable Definition="Definition" Records="Records" OnCreate="NewRecord" />
+
+@code {
+    [Parameter]
+    public string CollectionName { get; set; } = string.Empty;
+
+    private TheBackend.Admin.Services.DynamicCollection? Definition;
+    private List<Dictionary<string, object>>? Records;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        Definition = await CollectionService.GetCollectionAsync(CollectionName);
+        Records = await CollectionService.GetRecordsAsync(CollectionName);
+    }
+
+    private void NewRecord()
+    {
+        NavigationManager.NavigateTo($"/collections/{CollectionName}/record");
+    }
+}

--- a/TheBackend.Admin/Pages/CreateEditRecord.razor
+++ b/TheBackend.Admin/Pages/CreateEditRecord.razor
@@ -1,0 +1,12 @@
+@page "/collections/{CollectionName}/record/{RecordId?}"
+
+<h3>Edit Record</h3>
+<p>This is a stub page for collection <strong>@CollectionName</strong> with id <em>@RecordId</em>.</p>
+
+@code {
+    [Parameter]
+    public string CollectionName { get; set; } = string.Empty;
+
+    [Parameter]
+    public string? RecordId { get; set; }
+}

--- a/TheBackend.Admin/Program.cs
+++ b/TheBackend.Admin/Program.cs
@@ -9,5 +9,6 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri("https://localhost:7020/") });
 builder.Services.AddScoped<ApiClient>();
+builder.Services.AddSingleton<TheBackend.Admin.Services.CollectionService>();
 
 await builder.Build().RunAsync();

--- a/TheBackend.Admin/Services/CollectionService.cs
+++ b/TheBackend.Admin/Services/CollectionService.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using TheBackend.Domain.Models;
+
+namespace TheBackend.Admin.Services;
+
+public class CollectionService
+{
+    private readonly List<DynamicCollection> _collections = new()
+    {
+        new DynamicCollection
+        {
+            ModelName = "Articles",
+            Properties = new List<PropertyDefinition>
+            {
+                new PropertyDefinition { Name = "Id", Type = "number", IsKey = true },
+                new PropertyDefinition { Name = "Title", Type = "string", IsRequired = true },
+                new PropertyDefinition { Name = "Content", Type = "string" }
+            }
+        },
+        new DynamicCollection
+        {
+            ModelName = "Categories",
+            Properties = new List<PropertyDefinition>
+            {
+                new PropertyDefinition { Name = "Id", Type = "number", IsKey = true },
+                new PropertyDefinition { Name = "Name", Type = "string", IsRequired = true }
+            }
+        }
+    };
+
+    public Task<List<DynamicCollection>> GetCollectionsAsync() => Task.FromResult(_collections);
+
+    public Task<DynamicCollection?> GetCollectionAsync(string name)
+    {
+        var coll = _collections.FirstOrDefault(c => c.ModelName.Equals(name, StringComparison.OrdinalIgnoreCase));
+        return Task.FromResult(coll);
+    }
+
+    public Task<List<Dictionary<string, object>>> GetRecordsAsync(string name)
+    {
+        var list = new List<Dictionary<string, object>>();
+        if (name.Equals("Articles", StringComparison.OrdinalIgnoreCase))
+        {
+            list.Add(new Dictionary<string, object>
+            {
+                ["Id"] = 1,
+                ["Title"] = "First article",
+                ["Content"] = "Hello world"
+            });
+        }
+
+        return Task.FromResult(list);
+    }
+}

--- a/TheBackend.Admin/Services/DynamicCollection.cs
+++ b/TheBackend.Admin/Services/DynamicCollection.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using TheBackend.Domain.Models;
+
+namespace TheBackend.Admin.Services;
+
+public class DynamicCollection
+{
+    public string ModelName { get; set; } = string.Empty;
+    public List<PropertyDefinition> Properties { get; set; } = new();
+}

--- a/TheBackend.Admin/_Imports.razor
+++ b/TheBackend.Admin/_Imports.razor
@@ -9,6 +9,8 @@
 @using TheBackend.Admin
 @using TheBackend.Admin.Layout
 @using TheBackend.Admin.Shared
+@using TheBackend.Admin.Services
+@using TheBackend.Admin.Components
 @using TheBackend.Domain.Models
 @using System.Linq
 @using System.Text.Json


### PR DESCRIPTION
## Summary
- add sidebar, context sidebar and content header components
- create dynamic record table
- scaffold collection view and record edit pages
- implement dummy collection service
- wire layout to new sidebar

## Testing
- `dotnet format TheBackend.sln --no-restore`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`

------
https://chatgpt.com/codex/tasks/task_e_687ed76c85348324999ff06bf24bf289