### PR TITLE
Add simple user management

### DIFF
--- a/TheBackend.Admin/Layout/NavMenu.razor
+++ b/TheBackend.Admin/Layout/NavMenu.razor
@@ -21,5 +21,17 @@
                 Data
             </NavLink>
         </li>
+        <li class="nav-item mb-2">
+            <NavLink class="nav-link text-light" href="users">
+                <i class="bi bi-people"></i>
+                Users
+            </NavLink>
+        </li>
+        <li class="nav-item mb-2">
+            <NavLink class="nav-link text-light" href="login">
+                <i class="bi bi-box-arrow-in-right"></i>
+                Login
+            </NavLink>
+        </li>
     </ul>
 </nav>

--- a/TheBackend.Admin/Pages/Login.razor
+++ b/TheBackend.Admin/Pages/Login.razor
@@ -1,0 +1,33 @@
+@page "/login"
+@inject ApiClient Api
+@inject NavigationManager Nav
+
+<h3>Login</h3>
+
+@if (!string.IsNullOrEmpty(error))
+{
+    <div class="alert alert-danger">@error</div>
+}
+
+<EditForm Model="login" OnValidSubmit="HandleLogin">
+    <InputText class="form-control mb-2" @bind-Value="login.UserName" placeholder="Username" />
+    <InputText class="form-control mb-2" @bind-Value="login.Password" placeholder="Password" type="password" />
+    <button class="btn btn-primary" type="submit">Login</button>
+</EditForm>
+
+@code {
+    private AuthUser login = new();
+    private string? error;
+
+    private async Task HandleLogin()
+    {
+        var token = await Api.PostAsync<AuthUser, string>("api/auth/login", login);
+        if (token == null)
+        {
+            error = "Invalid credentials";
+            return;
+        }
+        Api.SetToken(token);
+        Nav.NavigateTo("/");
+    }
+}

--- a/TheBackend.Admin/Pages/Users.razor
+++ b/TheBackend.Admin/Pages/Users.razor
@@ -1,0 +1,38 @@
+@page "/users"
+@inject ApiClient Api
+
+<h3>Users</h3>
+
+@if (users == null)
+{
+    <p>Loading...</p>
+}
+else
+{
+    <table class="table">
+        <thead class="table-light">
+            <tr>
+                <th>UserName</th>
+                <th>Roles</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var u in users)
+            {
+                <tr>
+                    <td>@u.UserName</td>
+                    <td>@string.Join(",", u.Roles)</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+@code {
+    private List<AuthUser>? users;
+
+    protected override async Task OnInitializedAsync()
+    {
+        users = await Api.GetAsync<List<AuthUser>>("api/users");
+    }
+}

--- a/TheBackend.Admin/Shared/ApiClient.cs
+++ b/TheBackend.Admin/Shared/ApiClient.cs
@@ -7,10 +7,17 @@ namespace TheBackend.Admin.Shared;
 public class ApiClient
 {
     private readonly HttpClient _http;
+    private string? _token;
 
     public ApiClient(HttpClient http)
     {
         _http = http;
+    }
+
+    public void SetToken(string token)
+    {
+        _token = token;
+        _http.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
     }
 
     public async Task<T?> GetAsync<T>(string uri) where T : class

--- a/TheBackend.Admin/_Imports.razor
+++ b/TheBackend.Admin/_Imports.razor
@@ -10,6 +10,7 @@
 @using TheBackend.Admin.Layout
 @using TheBackend.Admin.Shared
 @using TheBackend.Domain.Models
+@using TheBackend.Domain.Models.Auth
 @using System.Linq
 @using System.Text.Json
 @using System.Text

--- a/TheBackend.Api/Controllers/AuthController.cs
+++ b/TheBackend.Api/Controllers/AuthController.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Mvc;
+using TheBackend.Application.Auth;
+using TheBackend.Domain.Models.Auth;
+
+namespace TheBackend.Api.Controllers;
+
+[ApiController]
+[Route("api/auth")]
+public class AuthController : ControllerBase
+{
+    private readonly IUserRepository _users;
+    private readonly AuthService _authService;
+
+    public AuthController(IUserRepository users, AuthService authService)
+    {
+        _users = users;
+        _authService = authService;
+    }
+
+    [HttpPost("login")]
+    public async Task<IActionResult> Login([FromBody] AuthUser request)
+    {
+        var token = await _authService.AuthenticateAsync(request.UserName, request.Password);
+        if (token == null) return Unauthorized(ApiResponse<string>.Fail("Invalid credentials"));
+        return Ok(ApiResponse<string>.Ok(token));
+    }
+
+    [HttpPost("register")]
+    public async Task<IActionResult> Register([FromBody] AuthUser user)
+    {
+        await _users.AddAsync(user);
+        return Ok(ApiResponse<AuthUser>.Ok(user));
+    }
+}

--- a/TheBackend.Api/Controllers/UsersController.cs
+++ b/TheBackend.Api/Controllers/UsersController.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using TheBackend.Application.Auth;
+using TheBackend.Domain.Models.Auth;
+
+namespace TheBackend.Api.Controllers;
+
+[ApiController]
+[Route("api/users")]
+[Authorize(Roles = "Admin")]
+public class UsersController : ControllerBase
+{
+    private readonly IUserRepository _users;
+
+    public UsersController(IUserRepository users)
+    {
+        _users = users;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetAll()
+    {
+        var result = await _users.GetAllAsync();
+        return Ok(ApiResponse<List<AuthUser>>.Ok(result));
+    }
+}

--- a/TheBackend.Api/Program.cs
+++ b/TheBackend.Api/Program.cs
@@ -1,6 +1,10 @@
 using TheBackend.DynamicModels;
 using TheBackend.Domain.Models;
 using TheBackend.Api.Middleware;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using TheBackend.Application.Auth;
+using TheBackend.Infrastructure.Auth;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
@@ -8,6 +12,15 @@ builder.Services.AddSingleton<ModelDefinitionService>();
 builder.Services.AddSingleton<DynamicDbContextService>();
 builder.Services.AddSingleton<BusinessRuleService>();
 builder.Services.AddTransient<ExceptionHandlingMiddleware>();
+builder.Services.AddSingleton<IUserRepository, InMemoryUserRepository>();
+builder.Services.AddSingleton<AuthService>();
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        var parameters = new AuthService(new InMemoryUserRepository()).GetValidationParameters();
+        options.TokenValidationParameters = parameters;
+    });
+builder.Services.AddAuthorization();
 
 builder.Services.AddCors(options =>
 {
@@ -26,6 +39,8 @@ app.Lifetime.ApplicationStopped.Register(() => dbService.Dispose());
 await dbService.RegenerateAndMigrateAsync();
 app.UseCors();
 app.UseMiddleware<ExceptionHandlingMiddleware>();
+app.UseAuthentication();
+app.UseAuthorization();
 
 
 app.MapControllers();

--- a/TheBackend.Api/TheBackend.Api.csproj
+++ b/TheBackend.Api/TheBackend.Api.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TheBackend.DynamicModels\TheBackend.DynamicModels.csproj" />

--- a/TheBackend.Application/Auth/AuthService.cs
+++ b/TheBackend.Application/Auth/AuthService.cs
@@ -1,0 +1,53 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.IdentityModel.Tokens;
+using TheBackend.Domain.Models.Auth;
+
+namespace TheBackend.Application.Auth;
+
+public class AuthService
+{
+    private readonly IUserRepository _userRepository;
+    private readonly byte[] _key = Encoding.UTF8.GetBytes("supersecretkey12345");
+
+    public AuthService(IUserRepository userRepository)
+    {
+        _userRepository = userRepository;
+    }
+
+    public async Task<string?> AuthenticateAsync(string userName, string password)
+    {
+        var user = await _userRepository.GetByUserNameAsync(userName);
+        if (user == null || user.Password != password) return null;
+
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.Name, user.UserName)
+        };
+        claims.AddRange(user.Roles.Select(r => new Claim(ClaimTypes.Role, r)));
+
+        var creds = new SigningCredentials(new SymmetricSecurityKey(_key), SecurityAlgorithms.HmacSha256);
+        var token = new JwtSecurityToken(
+            issuer: "TheBackend",
+            audience: "TheBackend",
+            claims: claims,
+            expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: creds);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    public TokenValidationParameters GetValidationParameters()
+    {
+        return new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateIssuerSigningKey = true,
+            ValidIssuer = "TheBackend",
+            ValidAudience = "TheBackend",
+            IssuerSigningKey = new SymmetricSecurityKey(_key)
+        };
+    }
+}

--- a/TheBackend.Application/Auth/IRoleRepository.cs
+++ b/TheBackend.Application/Auth/IRoleRepository.cs
@@ -1,0 +1,9 @@
+using TheBackend.Domain.Models.Auth;
+
+namespace TheBackend.Application.Auth;
+
+public interface IRoleRepository
+{
+    Task<List<AuthRole>> GetAllAsync();
+    Task AddAsync(AuthRole role);
+}

--- a/TheBackend.Application/Auth/IUserRepository.cs
+++ b/TheBackend.Application/Auth/IUserRepository.cs
@@ -1,0 +1,10 @@
+using TheBackend.Domain.Models.Auth;
+
+namespace TheBackend.Application.Auth;
+
+public interface IUserRepository
+{
+    Task<AuthUser?> GetByUserNameAsync(string userName);
+    Task<List<AuthUser>> GetAllAsync();
+    Task AddAsync(AuthUser user);
+}

--- a/TheBackend.Application/TheBackend.Application.csproj
+++ b/TheBackend.Application/TheBackend.Application.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../TheBackend.Domain/TheBackend.Domain.csproj" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.0.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/TheBackend.Domain/Models/Auth/AuthRole.cs
+++ b/TheBackend.Domain/Models/Auth/AuthRole.cs
@@ -1,0 +1,7 @@
+namespace TheBackend.Domain.Models.Auth;
+
+public class AuthRole
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}

--- a/TheBackend.Domain/Models/Auth/AuthUser.cs
+++ b/TheBackend.Domain/Models/Auth/AuthUser.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace TheBackend.Domain.Models.Auth;
+
+public class AuthUser
+{
+    public int Id { get; set; }
+    public string UserName { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+    public List<string> Roles { get; set; } = new();
+}

--- a/TheBackend.Infrastructure/Auth/InMemoryRoleRepository.cs
+++ b/TheBackend.Infrastructure/Auth/InMemoryRoleRepository.cs
@@ -1,0 +1,21 @@
+using TheBackend.Application.Auth;
+using TheBackend.Domain.Models.Auth;
+
+namespace TheBackend.Infrastructure.Auth;
+
+public class InMemoryRoleRepository : IRoleRepository
+{
+    private readonly List<AuthRole> _roles = new();
+
+    public Task AddAsync(AuthRole role)
+    {
+        role.Id = _roles.Count + 1;
+        _roles.Add(role);
+        return Task.CompletedTask;
+    }
+
+    public Task<List<AuthRole>> GetAllAsync()
+    {
+        return Task.FromResult(_roles.ToList());
+    }
+}

--- a/TheBackend.Infrastructure/Auth/InMemoryUserRepository.cs
+++ b/TheBackend.Infrastructure/Auth/InMemoryUserRepository.cs
@@ -1,0 +1,27 @@
+using TheBackend.Application.Auth;
+using TheBackend.Domain.Models.Auth;
+
+namespace TheBackend.Infrastructure.Auth;
+
+public class InMemoryUserRepository : IUserRepository
+{
+    private readonly List<AuthUser> _users = new();
+
+    public Task AddAsync(AuthUser user)
+    {
+        user.Id = _users.Count + 1;
+        _users.Add(user);
+        return Task.CompletedTask;
+    }
+
+    public Task<List<AuthUser>> GetAllAsync()
+    {
+        return Task.FromResult(_users.ToList());
+    }
+
+    public Task<AuthUser?> GetByUserNameAsync(string userName)
+    {
+        var user = _users.FirstOrDefault(u => u.UserName.Equals(userName, StringComparison.OrdinalIgnoreCase));
+        return Task.FromResult(user);
+    }
+}


### PR DESCRIPTION
## Summary
- implement basic AuthUser and AuthRole models
- add in-memory user and role repositories
- provide AuthService to create JWT tokens
- secure API endpoints with JWT auth
- create login and user listing pages in the admin UI

## Testing
- `dotnet format TheBackend.sln`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`

------
https://chatgpt.com/codex/tasks/task_e_687ed87309908324aef5d78a41390993