### PR TITLE
Fix postcss config

### DIFF
--- a/AdminUI/postcss.config.cjs
+++ b/AdminUI/postcss.config.cjs
@@ -1,6 +1,6 @@
 module.exports = {
-  plugins: [
-    require('@tailwindcss/postcss')(), // <- updated!
-    require('autoprefixer')
-  ]
-}
+    plugins: {
+        tailwindcss: {},
+        autoprefixer: {},
+    },
+};


### PR DESCRIPTION
## Summary
- update AdminUI postcss config to object-form plugin declaration
- install `tailwindcss` and `autoprefixer`

## Testing
- `dotnet format TheBackend.sln`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`
- `npm install` *(fails: npm warns engine requires Node >=20)*
- `npm run dev` *(fails: crypto.hash is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_687f3a173aa48324a68b990849311c60