### PR TITLE
Fix 404 for missing models

### DIFF
--- a/TheBackend.DynamicModels/DynamicDbContextService.cs
+++ b/TheBackend.DynamicModels/DynamicDbContextService.cs
@@ -274,10 +274,11 @@ namespace TheBackend.DynamicModels
         return sb.ToString();
     }
 
-    public Type GetModelType(string modelName) =>
-        _dynamicAssembly.GetTypes()
-            .FirstOrDefault(t => t.Name.Equals(modelName, StringComparison.OrdinalIgnoreCase))
-        ?? throw new Exception($"Model '{modelName}' not found");
+    public Type? GetModelType(string modelName)
+    {
+        return _dynamicAssembly.GetTypes()
+            .FirstOrDefault(t => t.Name.Equals(modelName, StringComparison.OrdinalIgnoreCase));
+    }
 
     public DbContext GetDbContext() => CreateDbContextInstance();
 

--- a/TheBackend.Tests/DynamicDbContextServiceTests.cs
+++ b/TheBackend.Tests/DynamicDbContextServiceTests.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Configuration;
+using TheBackend.DynamicModels;
+using Xunit;
+
+namespace TheBackend.Tests;
+
+public class DynamicDbContextServiceTests
+{
+    [Fact]
+    public void GetModelType_ReturnsNull_ForUnknownModel()
+    {
+        var modelService = new ModelDefinitionService();
+        var config = new ConfigurationBuilder().Build();
+        var service = new DynamicDbContextService(modelService, config);
+        typeof(DynamicDbContextService)
+            .GetField("_dynamicAssembly", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .SetValue(service, typeof(DynamicDbContextServiceTests).Assembly);
+
+        var type = service.GetModelType("UnknownModel");
+
+        Assert.Null(type);
+    }
+}

--- a/TheBackend.Tests/GenericControllerTests.cs
+++ b/TheBackend.Tests/GenericControllerTests.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Configuration;
+using TheBackend.Api;
+using TheBackend.Api.Controllers;
+using TheBackend.DynamicModels;
+using Xunit;
+
+namespace TheBackend.Tests;
+
+public class GenericControllerTests
+{
+    private static DynamicDbContextService CreateService()
+    {
+        var modelService = new ModelDefinitionService();
+        var config = new ConfigurationBuilder().Build();
+        var service = new DynamicDbContextService(modelService, config);
+        typeof(DynamicDbContextService)
+            .GetField("_dynamicAssembly", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .SetValue(service, typeof(GenericControllerTests).Assembly);
+        return service;
+    }
+
+    [Fact]
+    public async Task GetAll_ReturnsNotFound_ForUnknownModel()
+    {
+        using var dbService = CreateService();
+        var ruleService = new BusinessRuleService(Path.GetTempFileName());
+        var controller = new GenericController(dbService, ruleService, NullLogger<GenericController>.Instance);
+
+        var result = await controller.GetAll("UnknownModel");
+
+        var notFound = Assert.IsType<NotFoundObjectResult>(result);
+        var response = Assert.IsType<ApiResponse<object>>(notFound.Value);
+        Assert.Equal("Model not found", response.Message);
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsNotFound_ForUnknownModel()
+    {
+        using var dbService = CreateService();
+        var ruleService = new BusinessRuleService(Path.GetTempFileName());
+        var controller = new GenericController(dbService, ruleService, NullLogger<GenericController>.Instance);
+
+        var result = await controller.GetById("UnknownModel", "1");
+
+        var notFound = Assert.IsType<NotFoundObjectResult>(result);
+        var response = Assert.IsType<ApiResponse<object>>(notFound.Value);
+        Assert.Equal("Model not found", response.Message);
+    }
+}

--- a/TheBackend.Tests/TheBackend.Tests.csproj
+++ b/TheBackend.Tests/TheBackend.Tests.csproj
@@ -7,16 +7,17 @@
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="coverlet.collector" Version="6.0.2" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.7" />
-		<PackageReference Include="xunit" Version="2.9.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-	</ItemGroup>
+        <ItemGroup>
+                <PackageReference Include="coverlet.collector" Version="6.0.2" />
+                <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+                <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.7" />
+                <PackageReference Include="xunit" Version="2.9.2" />
+                <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+        </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="../TheBackend.Infrastructure/TheBackend.Infrastructure.csproj" />
-		<ProjectReference Include="../TheBackend.DynamicModels/TheBackend.DynamicModels.csproj" />
-	</ItemGroup>
+        <ItemGroup>
+                <ProjectReference Include="../TheBackend.Infrastructure/TheBackend.Infrastructure.csproj" />
+                <ProjectReference Include="../TheBackend.DynamicModels/TheBackend.DynamicModels.csproj" />
+                <ProjectReference Include="../TheBackend.Api/TheBackend.Api.csproj" />
+        </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- return `null` in `GetModelType` when model isn't found
- update tests project to reference Api project
- test `DynamicDbContextService.GetModelType` and generic controller

## Testing
- `dotnet format TheBackend.sln`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`


------
https://chatgpt.com/codex/tasks/task_e_687fbeb5975c8324ba35f47d5ca0a202