### PR TITLE
Wrap models endpoint response

### DIFF
--- a/AdminUI/src/services/models.ts
+++ b/AdminUI/src/services/models.ts
@@ -1,31 +1,12 @@
-// services/models.ts
 import api from './api';
-// You might need to adjust ApiResponse if its definition is forcing the `data` wrapper
-// or use a more flexible type for this specific call if your API structure varies.
 import type { ApiResponse, ModelDefinition } from '../types/models';
 
 export async function getModels(): Promise<ModelDefinition[]> {
-    console.log("getModels: Initiating API call to /models");
     try {
-        // Here, we're explicitly telling Axios to expect an array of ModelDefinition directly
-        // if your API doesn't wrap it in a `data` property.
-        // If your ApiResponse type is defined as `interface ApiResponse<T> { data: T; }`
-        // AND your backend returns `{"data": [...]}` then the original was correct.
-        // BUT, given your console log, it seems your backend returns `[...]` directly.
-        const res = await api.get<ModelDefinition[]>('/models'); // <--- Key change here: expect ModelDefinition[] directly
-
-        console.log("getModels: Raw API response received (res.data):", res.data); // Log the actual data property
-
-        // Check if res.data is an array
-        if (Array.isArray(res.data)) {
-            console.log("getModels: Data successfully extracted and is an array:", res.data);
-            return res.data; // <--- Key change here: return res.data directly
-        } else {
-            console.warn("getModels: API response for /models was not a direct array.", res.data);
-            return []; // Return an empty array if data is not an array
-        }
+        const res = await api.get<ApiResponse<ModelDefinition[]>>('/models');
+        return res.data.data;
     } catch (error) {
-        console.error("getModels: Error fetching models:", error);
+        console.error('getModels: Error fetching models:', error);
         return [];
     }
 }
@@ -33,9 +14,9 @@ export async function getModels(): Promise<ModelDefinition[]> {
 export async function saveModel(model: ModelDefinition): Promise<void> {
     try {
         await api.post('/models', model);
-        console.log("Model saved successfully:", model.modelName);
+        console.log('Model saved successfully:', model.modelName);
     } catch (error) {
-        console.error("Error saving model:", error);
+        console.error('Error saving model:', error);
         throw error;
     }
 }

--- a/TheBackend.Api/Controllers/ModelsController.cs
+++ b/TheBackend.Api/Controllers/ModelsController.cs
@@ -26,7 +26,7 @@ namespace TheBackend.Api.Controllers
         {
             _logger.LogInformation("List models");
             var models = _modelService.LoadModels();
-            return Ok(models);
+            return Ok(ApiResponse<List<ModelDefinition>>.Ok(models));
         }
 
         [HttpPost]

--- a/TheBackend.Tests/ModelsControllerTests.cs
+++ b/TheBackend.Tests/ModelsControllerTests.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using TheBackend.Api;
+using TheBackend.Api.Controllers;
+using TheBackend.Domain.Models;
+using TheBackend.DynamicModels;
+using Xunit;
+
+namespace TheBackend.Tests;
+
+public class ModelsControllerTests
+{
+    [Fact]
+    public void GetModels_ReturnsWrappedResponse()
+    {
+        var originalDir = Directory.GetCurrentDirectory();
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        Directory.SetCurrentDirectory(tempDir);
+        try
+        {
+            var service = new ModelDefinitionService();
+            var models = new List<ModelDefinition>
+            {
+                new ModelDefinition { ModelName = "Sample", Properties = new List<PropertyDefinition>() }
+            };
+            service.SaveModels(models);
+
+            var config = new ConfigurationBuilder().Build();
+            using var dbService = new DynamicDbContextService(service, config);
+            var controller = new ModelsController(service, dbService, NullLogger<ModelsController>.Instance);
+
+            var result = controller.GetModels();
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var response = Assert.IsType<ApiResponse<List<ModelDefinition>>>(ok.Value);
+            Assert.True(response.Success);
+            Assert.NotNull(response.Data);
+            Assert.Single(response.Data!);
+            Assert.Equal("Sample", response.Data![0].ModelName);
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalDir);
+            Directory.Delete(tempDir, true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- wrap models endpoint in `ApiResponse` for consistency
- adapt AdminUI model service to unwrap data
- test `ModelsController.GetModels` returns wrapped response

## Testing
- `dotnet format TheBackend.sln --no-restore`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`


------
https://chatgpt.com/codex/tasks/task_e_687fc5921ae883248e816dd01c2aef2e