### PR TITLE
Add relationship mapping generation

### DIFF
--- a/TheBackend.DynamicModels/DynamicDbContextService.cs
+++ b/TheBackend.DynamicModels/DynamicDbContextService.cs
@@ -277,6 +277,62 @@ namespace TheBackend.DynamicModels
                 if (prop.IsRequired) sb.AppendLine($"                entity.Property(e => e.{prop.Name}).IsRequired();");
                 if (prop.MaxLength.HasValue) sb.AppendLine($"                entity.Property(e => e.{prop.Name}).HasMaxLength({prop.MaxLength});");
             }
+            foreach (var rel in model.Relationships)
+            {
+                var hasFk = !string.IsNullOrWhiteSpace(rel.ForeignKey);
+                var inverse = string.IsNullOrWhiteSpace(rel.InverseNavigation) ? null : rel.InverseNavigation;
+                switch (rel.RelationshipType)
+                {
+                    case "ManyToOne":
+                        sb.AppendLine($"                entity.HasOne<{rel.TargetModel}>(e => e.{rel.NavigationName})");
+                        sb.Append("                    .WithMany(");
+                        sb.Append(string.IsNullOrWhiteSpace(inverse) ? ")" : $"d => d.{inverse})");
+                        if (hasFk)
+                        {
+                            sb.AppendLine();
+                            sb.AppendLine($"                    .HasForeignKey(e => e.{rel.ForeignKey});");
+                        }
+                        else
+                        {
+                            sb.AppendLine(";");
+                        }
+                        break;
+                    case "OneToMany":
+                        sb.AppendLine($"                entity.HasMany(e => e.{rel.NavigationName})");
+                        sb.Append("                    .WithOne(");
+                        sb.Append(string.IsNullOrWhiteSpace(inverse) ? ")" : $"d => d.{inverse})");
+                        if (hasFk)
+                        {
+                            sb.AppendLine();
+                            sb.AppendLine($"                    .HasForeignKey<{rel.TargetModel}>(d => d.{rel.ForeignKey});");
+                        }
+                        else
+                        {
+                            sb.AppendLine(";");
+                        }
+                        break;
+                    case "OneToOne":
+                        sb.AppendLine($"                entity.HasOne<{rel.TargetModel}>(e => e.{rel.NavigationName})");
+                        sb.Append("                    .WithOne(");
+                        sb.Append(string.IsNullOrWhiteSpace(inverse) ? ")" : $"d => d.{inverse})");
+                        if (hasFk)
+                        {
+                            sb.AppendLine();
+                            sb.AppendLine($"                    .HasForeignKey<{model.ModelName}>(e => e.{rel.ForeignKey});");
+                        }
+                        else
+                        {
+                            sb.AppendLine(";");
+                        }
+                        break;
+                    case "ManyToMany":
+                        sb.AppendLine($"                entity.HasMany(e => e.{rel.NavigationName})");
+                        sb.Append("                    .WithMany(");
+                        sb.Append(string.IsNullOrWhiteSpace(inverse) ? ")" : $"d => d.{inverse})");
+                        sb.AppendLine(";");
+                        break;
+                }
+            }
             sb.AppendLine("            });");
         }
         sb.AppendLine("        }");


### PR DESCRIPTION
## Summary
- extend `GenerateDbContextCode` to write EF Core relationship configuration
- inspect model `Relationships` and emit `HasOne`, `HasMany` etc.

## Testing
- `dotnet format TheBackend.sln --verbosity diag`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`


------
https://chatgpt.com/codex/tasks/task_e_688018da3dbc8324819cacf4b2bbcaa7