### PR TITLE
Implement model history persistence

### DIFF
--- a/TheBackend.Api/Program.cs
+++ b/TheBackend.Api/Program.cs
@@ -6,6 +6,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
 builder.Services.AddSingleton<ModelDefinitionService>();
 builder.Services.AddSingleton<DynamicDbContextService>();
+builder.Services.AddSingleton<ModelHistoryService>();
 builder.Services.AddSingleton<BusinessRuleService>();
 builder.Services.AddTransient<ExceptionHandlingMiddleware>();
 

--- a/TheBackend.Domain/Models/ModelHistory.cs
+++ b/TheBackend.Domain/Models/ModelHistory.cs
@@ -1,0 +1,12 @@
+namespace TheBackend.Domain.Models
+{
+    public class ModelHistory
+    {
+        public int Id { get; set; }
+        public string ModelName { get; set; } = string.Empty;
+        public string Action { get; set; } = string.Empty;
+        public string Definition { get; set; } = string.Empty;
+        public string Hash { get; set; } = string.Empty;
+        public DateTime Timestamp { get; set; }
+    }
+}

--- a/TheBackend.DynamicModels/ModelHistoryDbContext.cs
+++ b/TheBackend.DynamicModels/ModelHistoryDbContext.cs
@@ -1,0 +1,11 @@
+using Microsoft.EntityFrameworkCore;
+using TheBackend.Domain.Models;
+
+namespace TheBackend.DynamicModels;
+
+public class ModelHistoryDbContext : DbContext
+{
+    public DbSet<ModelHistory> ModelHistories { get; set; } = default!;
+
+    public ModelHistoryDbContext(DbContextOptions<ModelHistoryDbContext> options) : base(options) { }
+}

--- a/TheBackend.DynamicModels/ModelHistoryService.cs
+++ b/TheBackend.DynamicModels/ModelHistoryService.cs
@@ -1,0 +1,70 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using TheBackend.Domain.Models;
+
+namespace TheBackend.DynamicModels;
+
+public class ModelHistoryService
+{
+    private readonly DbContextOptions<ModelHistoryDbContext> _options;
+
+    public ModelHistoryService(IConfiguration config)
+    {
+        var builder = new DbContextOptionsBuilder<ModelHistoryDbContext>();
+        var connString = config.GetConnectionString("Default");
+        var provider = config["DbProvider"];
+        if (provider == "SqlServer")
+            builder.UseSqlServer(connString);
+        else if (provider == "Postgres")
+            builder.UseNpgsql(connString);
+        else
+            builder.UseInMemoryDatabase("ModelHistory");
+        _options = builder.Options;
+
+        using var ctx = new ModelHistoryDbContext(_options);
+        if (provider == "SqlServer" || provider == "Postgres")
+            ctx.Database.Migrate();
+        else
+            ctx.Database.EnsureCreated();
+    }
+
+    public string? GetLastHash()
+    {
+        using var ctx = new ModelHistoryDbContext(_options);
+        return ctx.ModelHistories
+            .OrderByDescending(h => h.Timestamp)
+            .Select(h => h.Hash)
+            .FirstOrDefault();
+    }
+
+    public void RecordSnapshot(string hash)
+    {
+        using var ctx = new ModelHistoryDbContext(_options);
+        var entry = new ModelHistory
+        {
+            ModelName = string.Empty,
+            Action = "Snapshot",
+            Definition = string.Empty,
+            Hash = hash,
+            Timestamp = DateTime.UtcNow
+        };
+        ctx.ModelHistories.Add(entry);
+        ctx.SaveChanges();
+    }
+
+    public void RecordModelChange(ModelDefinition definition, string action, string hash)
+    {
+        using var ctx = new ModelHistoryDbContext(_options);
+        var entry = new ModelHistory
+        {
+            ModelName = definition.ModelName,
+            Action = action,
+            Definition = JsonConvert.SerializeObject(definition),
+            Hash = hash,
+            Timestamp = DateTime.UtcNow
+        };
+        ctx.ModelHistories.Add(entry);
+        ctx.SaveChanges();
+    }
+}

--- a/TheBackend.Tests/DynamicDbContextServiceTests.cs
+++ b/TheBackend.Tests/DynamicDbContextServiceTests.cs
@@ -11,7 +11,8 @@ public class DynamicDbContextServiceTests
     {
         var modelService = new ModelDefinitionService();
         var config = new ConfigurationBuilder().Build();
-        var service = new DynamicDbContextService(modelService, config);
+        var history = new ModelHistoryService(config);
+        var service = new DynamicDbContextService(modelService, config, history);
         typeof(DynamicDbContextService)
             .GetField("_dynamicAssembly", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
             .SetValue(service, typeof(DynamicDbContextServiceTests).Assembly);

--- a/TheBackend.Tests/GenericControllerTests.cs
+++ b/TheBackend.Tests/GenericControllerTests.cs
@@ -17,7 +17,8 @@ public class GenericControllerTests
     {
         var modelService = new ModelDefinitionService();
         var config = new ConfigurationBuilder().Build();
-        var service = new DynamicDbContextService(modelService, config);
+        var history = new ModelHistoryService(config);
+        var service = new DynamicDbContextService(modelService, config, history);
         typeof(DynamicDbContextService)
             .GetField("_dynamicAssembly", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
             .SetValue(service, typeof(GenericControllerTests).Assembly);
@@ -34,7 +35,8 @@ public class GenericControllerTests
                 ["ConnectionStrings:Default"] = Guid.NewGuid().ToString()
             })
             .Build();
-        var service = new DynamicDbContextService(modelService, config);
+        var history = new ModelHistoryService(config);
+        var service = new DynamicDbContextService(modelService, config, history);
         typeof(DynamicDbContextService)
             .GetField("_dynamicAssembly", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
             .SetValue(service, typeof(TestEntity).Assembly);

--- a/TheBackend.Tests/ModelsControllerTests.cs
+++ b/TheBackend.Tests/ModelsControllerTests.cs
@@ -28,8 +28,9 @@ public class ModelsControllerTests
             service.SaveModels(models);
 
             var config = new ConfigurationBuilder().Build();
-            using var dbService = new DynamicDbContextService(service, config);
-            var controller = new ModelsController(service, dbService, NullLogger<ModelsController>.Instance);
+            var history = new ModelHistoryService(config);
+            using var dbService = new DynamicDbContextService(service, config, history);
+            var controller = new ModelsController(service, dbService, history, NullLogger<ModelsController>.Instance);
 
             var result = controller.GetModels();
 


### PR DESCRIPTION
## Summary
- add `ModelHistory` entity to store model change logs
- persist hashes and changes through new `ModelHistoryService`
- update `DynamicDbContextService` to consult and record history
- inject `ModelHistoryService` via DI
- log create/update events in `ModelsController`
- adapt tests for the new dependencies

## Testing
- `dotnet format TheBackend.sln --verify-no-changes`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6880324716008324bdad4894c9507fd2