### PR TITLE
Add drawer for browsing records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -413,3 +413,4 @@ FodyWeavers.xsd
 *.msix
 *.msm
 *.msp
+*.tsbuildinfo

--- a/AdminUI/src/components/DataTable.tsx
+++ b/AdminUI/src/components/DataTable.tsx
@@ -8,9 +8,10 @@ interface Column<T> {
 interface Props<T> {
     columns: Column<T>[];
     data: T[];
+    onRowClick?: (row: T) => void;
 }
 
-export function DataTable<T>({ columns, data }: Props<T>) {
+export function DataTable<T>({ columns, data, onRowClick }: Props<T>) {
     return (
         <table className="min-w-full divide-y divide-gray-200 dark:divide-neutral-700">
             <thead className="bg-gray-50 dark:bg-neutral-800">
@@ -24,7 +25,11 @@ export function DataTable<T>({ columns, data }: Props<T>) {
             </thead>
             <tbody className="bg-white dark:bg-neutral-900 divide-y divide-gray-200 dark:divide-neutral-700">
                 {data.map((row, idx) => (
-                    <tr key={idx}>
+                    <tr
+                        key={idx}
+                        onClick={() => onRowClick?.(row)}
+                        className={onRowClick ? 'cursor-pointer hover:bg-gray-100 dark:hover:bg-neutral-800' : ''}
+                    >
                         {columns.map((col, i) => (
                             <td key={i} className="px-3 py-2 whitespace-nowrap">
                                 {col.accessor(row)}

--- a/AdminUI/src/pages/DataBrowser.tsx
+++ b/AdminUI/src/pages/DataBrowser.tsx
@@ -1,14 +1,20 @@
 import { useEffect, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { getModels } from '../services/models';
-import { getRecords, deleteRecord } from '../services/data';
+import { getRecords, deleteRecord, saveRecord } from '../services/data';
 import type { ModelDefinition } from '../types/models';
 import { DataTable } from '../components/DataTable';
+import { Drawer } from '../components/Drawer';
+import { FormFieldBuilder } from '../components/FormFieldBuilder';
 
 export default function DataBrowser() {
     const { name } = useParams();
     const [model, setModel] = useState<ModelDefinition | null>(null);
     const [records, setRecords] = useState<Record<string, unknown>[]>([]);
+    const [selected, setSelected] = useState<Record<string, unknown> | null>(null);
+    const [drawerOpen, setDrawerOpen] = useState(false);
+    const [isCreating, setIsCreating] = useState(false);
+    const [formValues, setFormValues] = useState<Record<string, unknown>>({});
 
     useEffect(() => {
         if (!name) return;
@@ -26,6 +32,20 @@ export default function DataBrowser() {
         setRecords(r => r.filter(x => (x as Record<string, unknown>).id !== id && (x as Record<string, unknown>).Id !== id));
     };
 
+    const openCreate = () => {
+        setFormValues({});
+        setIsCreating(true);
+        setDrawerOpen(true);
+    };
+
+    const create = async () => {
+        if (!name) return;
+        await saveRecord(name, formValues);
+        const list = await getRecords(name);
+        setRecords(list);
+        setDrawerOpen(false);
+    };
+
     if (!model) return <div>Loading...</div>;
 
     const columns = model.properties.map(p => ({
@@ -36,24 +56,45 @@ export default function DataBrowser() {
     columns.push({
         header: '',
         accessor: (row: Record<string, unknown>) => (
-            <div className="space-x-2">
-                <Link className="text-blue-600" to={`/data/${name}/${(row as Record<string, unknown>).id ?? (row as Record<string, unknown>).Id}`}>Edit</Link>
-                <button className="text-red-600" onClick={() => remove((row as Record<string, unknown>).id ?? (row as Record<string, unknown>).Id)}>
-                    Delete
-                </button>
-            </div>
+            <button className="text-red-600" onClick={() => remove((row as Record<string, unknown>).id ?? (row as Record<string, unknown>).Id)}>
+                Delete
+            </button>
         ),
     });
+
+    const fields = model.properties.map(p => ({ name: p.name, label: p.name, type: 'text' }));
 
     return (
         <div className="space-y-4">
             <div className="flex items-center justify-between">
                 <h2 className="text-xl font-semibold">{name}</h2>
-                <Link className="px-3 py-1 rounded bg-blue-600 text-white" to={`/data/${name}/new`}>
+                <button className="px-3 py-1 rounded bg-blue-600 text-white" onClick={openCreate}>
                     New Record
-                </Link>
+                </button>
             </div>
-            <DataTable columns={columns} data={records} />
+            <DataTable columns={columns} data={records} onRowClick={r => { setSelected(r); setIsCreating(false); setDrawerOpen(true); }} />
+            <Drawer open={drawerOpen} onClose={() => setDrawerOpen(false)}>
+                {isCreating ? (
+                    <div className="p-4 space-y-4">
+                        <h3 className="text-lg font-semibold mb-2">New {name}</h3>
+                        <FormFieldBuilder fields={fields} values={formValues} onChange={(n, v) => setFormValues({ ...formValues, [n]: v })} />
+                        <button className="px-3 py-1 rounded bg-blue-600 text-white" onClick={create}>
+                            Create
+                        </button>
+                    </div>
+                ) : selected ? (
+                    <div className="p-4 space-y-2">
+                        <h3 className="text-lg font-semibold mb-2">Details</h3>
+                        <ul className="space-y-1">
+                            {Object.entries(selected).map(([k, v]) => (
+                                <li key={k}>
+                                    <span className="font-semibold">{k}:</span> {String(v)}
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                ) : null}
+            </Drawer>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- enable row click in `DataTable`
- show a drawer with record details when clicking a row
- allow creating new records from the drawer
- ignore tsbuildinfo files

## Testing
- `dotnet format TheBackend.sln -v diag`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`

------
https://chatgpt.com/codex/tasks/task_e_6880327de4208324bd6731a4d61e5e22