### PR TITLE
Handle history schema creation correctly

### DIFF
--- a/TheBackend.DynamicModels/ModelHistoryService.cs
+++ b/TheBackend.DynamicModels/ModelHistoryService.cs
@@ -25,8 +25,7 @@ public class ModelHistoryService
         using var ctx = new ModelHistoryDbContext(_options);
         if (provider == "SqlServer" || provider == "Postgres")
             ctx.Database.Migrate();
-        else
-            ctx.Database.EnsureCreated();
+        ctx.Database.EnsureCreated();
     }
 
     public string? GetLastHash()


### PR DESCRIPTION
## Summary
- adjust `ModelHistoryService` to run migrations before ensuring schema

## Testing
- `dotnet format TheBackend.sln --no-restore`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`


------
https://chatgpt.com/codex/tasks/task_e_68803512a3f883249c56a2f5e595dc1b