### PR TITLE
Initialize ModelHistory on startup

### DIFF
--- a/TheBackend.Api/Program.cs
+++ b/TheBackend.Api/Program.cs
@@ -25,6 +25,9 @@ var app = builder.Build();
 var dbService = app.Services.GetRequiredService<DynamicDbContextService>();
 app.Lifetime.ApplicationStopped.Register(() => dbService.Dispose());
 await dbService.RegenerateAndMigrateAsync();
+var modelService = app.Services.GetRequiredService<ModelDefinitionService>();
+var historyService = app.Services.GetRequiredService<ModelHistoryService>();
+historyService.EnsureHistory(modelService.LoadModels(), modelService.ComputeModelsHash());
 app.UseCors();
 app.UseMiddleware<ExceptionHandlingMiddleware>();
 

--- a/TheBackend.Tests/ModelHistoryServiceTests.cs
+++ b/TheBackend.Tests/ModelHistoryServiceTests.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.EntityFrameworkCore;
+using TheBackend.Domain.Models;
+using TheBackend.DynamicModels;
+using Xunit;
+
+namespace TheBackend.Tests;
+
+public class ModelHistoryServiceTests
+{
+    [Fact]
+    public void EnsureHistory_CreatesEntriesOnlyOnce()
+    {
+        var models = new List<ModelDefinition>
+        {
+            new ModelDefinition { ModelName = "Test", Properties = new List<PropertyDefinition>() }
+        };
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["DbProvider"] = "InMemory",
+                ["ConnectionStrings:Default"] = Guid.NewGuid().ToString()
+            })
+            .Build();
+
+        var service = new ModelHistoryService(config);
+        service.EnsureHistory(models, "hash");
+        service.EnsureHistory(models, "hash");
+
+        var options = new DbContextOptionsBuilder<ModelHistoryDbContext>()
+            .UseInMemoryDatabase("ModelHistory")
+            .Options;
+        using var ctx = new ModelHistoryDbContext(options);
+        var entries = ctx.ModelHistories.ToList();
+        Assert.Equal(2, entries.Count);
+        Assert.Contains(entries, e => e.Action == "Created" && e.ModelName == "Test");
+        Assert.Contains(entries, e => e.Action == "Snapshot");
+    }
+}


### PR DESCRIPTION
## Summary
- add `EnsureHistory` method for model history seeding
- seed model history from `models.json` in Program startup
- test seeding behaviour

## Testing
- `dotnet format TheBackend.sln --no-restore`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`


------
https://chatgpt.com/codex/tasks/task_e_68803931fe5c832484f90126f9490c17