### PR TITLE
Add ModelHistory to DynamicDbContext

### DIFF
--- a/TheBackend.DynamicModels/DynamicDbContext.cs
+++ b/TheBackend.DynamicModels/DynamicDbContext.cs
@@ -1,13 +1,17 @@
 using Microsoft.EntityFrameworkCore;
+using TheBackend.Domain.Models;
+
 namespace TheBackend.DynamicModels
 {
     public class DynamicDbContext : DbContext
     {
         public DynamicDbContext(DbContextOptions<DynamicDbContext> options) : base(options) { }
 
+        public DbSet<ModelHistory> ModelHistories { get; set; } = default!;
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-
+            modelBuilder.Entity<ModelHistory>();
         }
     }
 }

--- a/TheBackend.DynamicModels/DynamicDbContextService.cs
+++ b/TheBackend.DynamicModels/DynamicDbContextService.cs
@@ -308,6 +308,7 @@ namespace TheBackend.DynamicModels
     {
         var sb = new StringBuilder();
         sb.AppendLine("using Microsoft.EntityFrameworkCore;");
+        sb.AppendLine("using TheBackend.Domain.Models;");
         sb.AppendLine($"namespace {@namespace}");
         sb.AppendLine("{");
         sb.AppendLine("    public class DynamicDbContext : DbContext");
@@ -315,6 +316,7 @@ namespace TheBackend.DynamicModels
         sb.AppendLine("        public DynamicDbContext(DbContextOptions<DynamicDbContext> options) : base(options) {}");
         foreach (var model in models)
             sb.AppendLine($"        public DbSet<{model.ModelName}> {model.ModelName}s {{ get; set; }}");
+        sb.AppendLine("        public DbSet<ModelHistory> ModelHistories { get; set; } = default!;");
         sb.AppendLine("        protected override void OnModelCreating(ModelBuilder modelBuilder)");
         sb.AppendLine("        {");
         foreach (var model in models)
@@ -391,6 +393,7 @@ namespace TheBackend.DynamicModels
             }
             sb.AppendLine("            });");
         }
+        sb.AppendLine("            modelBuilder.Entity<ModelHistory>();");
         sb.AppendLine("        }");
         sb.AppendLine("    }");
         sb.AppendLine("}");


### PR DESCRIPTION
## Summary
- include `ModelHistory` table in `DynamicDbContext`
- generate the `ModelHistory` mapping in DynamicDbContextService

## Testing
- `dotnet format TheBackend.sln`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`

------
https://chatgpt.com/codex/tasks/task_e_68803a816aec8324a4c92255e5fcb4b5