### PR TITLE
Add workflow steps for post/comment

### DIFF
--- a/TheBackend.Api/workflows.json
+++ b/TheBackend.Api/workflows.json
@@ -14,5 +14,12 @@
         "Type": "CreateComment"
       }
     ]
+  },
+  {
+    "WorkflowName": "User.AfterCreate",
+    "Steps": [
+      { "Type": "CreatePost" },
+      { "Type": "CreateComment" }
+    ]
   }
 ]

--- a/TheBackend.DynamicModels/Workflows/WorkflowService.cs
+++ b/TheBackend.DynamicModels/Workflows/WorkflowService.cs
@@ -84,6 +84,34 @@ public class WorkflowService
                 type.GetProperty("Total")?.SetValue(invoice, amountProp?.GetValue(entity));
                 db.Add(invoice);
                 await db.SaveChangesAsync();
+                entity = invoice;
+            }
+            else if (step.Type.Equals("CreatePost", StringComparison.OrdinalIgnoreCase))
+            {
+                var type = dbContextService.GetModelType("Post");
+                if (type == null) continue;
+                var db = dbContextService.GetDbContext();
+                var post = Activator.CreateInstance(type)!;
+                var idProp = entity.GetType().GetProperty("Id");
+                type.GetProperty("UserId")?.SetValue(post, idProp?.GetValue(entity));
+                type.GetProperty("Title")?.SetValue(post, "Auto generated post");
+                type.GetProperty("Content")?.SetValue(post, "Created via workflow");
+                db.Add(post);
+                await db.SaveChangesAsync();
+                entity = post;
+            }
+            else if (step.Type.Equals("CreateComment", StringComparison.OrdinalIgnoreCase))
+            {
+                var type = dbContextService.GetModelType("Comment");
+                if (type == null) continue;
+                var db = dbContextService.GetDbContext();
+                var comment = Activator.CreateInstance(type)!;
+                var postIdProp = entity.GetType().GetProperty("Id");
+                type.GetProperty("PostId")?.SetValue(comment, postIdProp?.GetValue(entity));
+                type.GetProperty("Content")?.SetValue(comment, "Auto comment");
+                db.Add(comment);
+                await db.SaveChangesAsync();
+                entity = comment;
             }
         }
     }


### PR DESCRIPTION
## Summary
- add CreatePost and CreateComment actions in `WorkflowService`
- run new workflow `User.AfterCreate` with steps to create post and comment
- update workflow definitions

## Testing
- `dotnet format TheBackend.sln`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`

------
https://chatgpt.com/codex/tasks/task_e_6883f9d2f8b08324b6a5b453c5b4b500