### PR TITLE
Persist workflows in database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Nothing.
+
+## [0.2.0] - 2025-07-25
+### Added
+- Workflow definitions persisted to database via `WorkflowHistoryService`.
+- Change log entries stored when workflows are saved.
+### Changed
+- `WorkflowService` now loads and saves workflows from the database in addition to JSON.

--- a/TheBackend.Api/Program.cs
+++ b/TheBackend.Api/Program.cs
@@ -10,6 +10,7 @@ builder.Services.AddSingleton<ModelDefinitionService>();
 builder.Services.AddSingleton<DynamicDbContextService>();
 builder.Services.AddSingleton<ModelHistoryService>();
 builder.Services.AddSingleton<RuleHistoryService>();
+builder.Services.AddSingleton<WorkflowHistoryService>();
 builder.Services.AddSingleton<BusinessRuleService>();
 builder.Services.AddSingleton<WorkflowService>();
 builder.Services.AddTransient<ExceptionHandlingMiddleware>();

--- a/TheBackend.Domain/Models/WorkflowDefinitionRecord.cs
+++ b/TheBackend.Domain/Models/WorkflowDefinitionRecord.cs
@@ -1,0 +1,9 @@
+namespace TheBackend.Domain.Models
+{
+    public class WorkflowDefinitionRecord
+    {
+        public int Id { get; set; }
+        public string WorkflowName { get; set; } = string.Empty;
+        public string Definition { get; set; } = string.Empty;
+    }
+}

--- a/TheBackend.Domain/Models/WorkflowHistory.cs
+++ b/TheBackend.Domain/Models/WorkflowHistory.cs
@@ -1,0 +1,12 @@
+namespace TheBackend.Domain.Models
+{
+    public class WorkflowHistory
+    {
+        public int Id { get; set; }
+        public string WorkflowName { get; set; } = string.Empty;
+        public string Action { get; set; } = string.Empty;
+        public string Definition { get; set; } = string.Empty;
+        public string Hash { get; set; } = string.Empty;
+        public DateTime Timestamp { get; set; }
+    }
+}

--- a/TheBackend.DynamicModels/ModelHistoryDbContext.cs
+++ b/TheBackend.DynamicModels/ModelHistoryDbContext.cs
@@ -7,6 +7,8 @@ public class ModelHistoryDbContext : DbContext
 {
     public DbSet<ModelHistory> ModelHistories { get; set; } = default!;
     public DbSet<RuleHistory> RuleHistories { get; set; } = default!;
+    public DbSet<WorkflowDefinitionRecord> WorkflowDefinitions { get; set; } = default!;
+    public DbSet<WorkflowHistory> WorkflowHistories { get; set; } = default!;
 
     public ModelHistoryDbContext(DbContextOptions<ModelHistoryDbContext> options) : base(options) { }
 }

--- a/TheBackend.DynamicModels/Workflows/WorkflowHistoryService.cs
+++ b/TheBackend.DynamicModels/Workflows/WorkflowHistoryService.cs
@@ -1,0 +1,81 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using TheBackend.Domain.Models;
+
+namespace TheBackend.DynamicModels.Workflows;
+
+public class WorkflowHistoryService
+{
+    private readonly DbContextOptions<ModelHistoryDbContext> _options;
+
+    public WorkflowHistoryService(IConfiguration config)
+    {
+        var builder = new DbContextOptionsBuilder<ModelHistoryDbContext>();
+        var connString = config.GetConnectionString("Default");
+        var provider = config["DbProvider"];
+        if (provider == "SqlServer")
+            builder.UseSqlServer(connString);
+        else if (provider == "Postgres")
+            builder.UseNpgsql(connString);
+        else
+            builder.UseInMemoryDatabase("ModelHistory");
+        _options = builder.Options;
+
+        using var ctx = new ModelHistoryDbContext(_options);
+        ctx.Database.EnsureCreated();
+    }
+
+    public List<WorkflowDefinition> LoadDefinitions(string? file)
+    {
+        using var ctx = new ModelHistoryDbContext(_options);
+        var defs = ctx.WorkflowDefinitions
+            .Select(d => JsonConvert.DeserializeObject<WorkflowDefinition>(d.Definition)!)
+            .ToList();
+        if (defs.Count == 0 && file != null && File.Exists(file))
+        {
+            var json = File.ReadAllText(file);
+            defs = JsonConvert.DeserializeObject<List<WorkflowDefinition>>(json) ?? new();
+            foreach (var def in defs)
+                SaveDefinition(def);
+        }
+        return defs;
+    }
+
+    public void SaveDefinition(WorkflowDefinition def)
+    {
+        using var ctx = new ModelHistoryDbContext(_options);
+        var json = JsonConvert.SerializeObject(def);
+        var existing = ctx.WorkflowDefinitions
+            .FirstOrDefault(x => x.WorkflowName.Equals(def.WorkflowName, StringComparison.OrdinalIgnoreCase));
+        if (existing == null)
+            ctx.WorkflowDefinitions.Add(new WorkflowDefinitionRecord { WorkflowName = def.WorkflowName, Definition = json });
+        else
+            existing.Definition = json;
+        ctx.SaveChanges();
+    }
+
+    public void RecordChange(WorkflowDefinition def, string action, string hash)
+    {
+        using var ctx = new ModelHistoryDbContext(_options);
+        var entry = new WorkflowHistory
+        {
+            WorkflowName = def.WorkflowName,
+            Action = action,
+            Definition = JsonConvert.SerializeObject(def),
+            Hash = hash,
+            Timestamp = DateTime.UtcNow
+        };
+        ctx.WorkflowHistories.Add(entry);
+        ctx.SaveChanges();
+    }
+
+    public string? GetLastHash()
+    {
+        using var ctx = new ModelHistoryDbContext(_options);
+        return ctx.WorkflowHistories
+            .OrderByDescending(h => h.Timestamp)
+            .Select(h => h.Hash)
+            .FirstOrDefault();
+    }
+}

--- a/TheBackend.Tests/GenericControllerTests.cs
+++ b/TheBackend.Tests/GenericControllerTests.cs
@@ -47,12 +47,19 @@ public class GenericControllerTests
         return service;
     }
 
+    private static WorkflowService CreateWorkflowService()
+    {
+        var config = new ConfigurationBuilder().Build();
+        var history = new WorkflowHistoryService(config);
+        return new WorkflowService(config, history);
+    }
+
     [Fact]
     public async Task GetAll_ReturnsNotFound_ForUnknownModel()
     {
         using var dbService = CreateService();
         var ruleService = new BusinessRuleService(Path.GetTempFileName());
-        var wfService = new WorkflowService();
+        var wfService = CreateWorkflowService();
         var controller = new GenericController(dbService, ruleService, wfService, NullLogger<GenericController>.Instance);
 
         var result = await controller.GetAll("UnknownModel");
@@ -67,7 +74,7 @@ public class GenericControllerTests
     {
         using var dbService = CreateService();
         var ruleService = new BusinessRuleService(Path.GetTempFileName());
-        var wfService = new WorkflowService();
+        var wfService = CreateWorkflowService();
         var controller = new GenericController(dbService, ruleService, wfService, NullLogger<GenericController>.Instance);
 
         var result = await controller.GetById("UnknownModel", "1");
@@ -85,7 +92,7 @@ public class GenericControllerTests
         try
         {
             var ruleService = new BusinessRuleService(tempFile);
-            var wfService = new WorkflowService();
+            var wfService = CreateWorkflowService();
             var controller = new GenericController(dbService, ruleService, wfService, NullLogger<GenericController>.Instance)
             {
                 ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
@@ -116,7 +123,7 @@ public class GenericControllerTests
         try
         {
             var ruleService = new BusinessRuleService(tempFile);
-            var wfService = new WorkflowService();
+            var wfService = CreateWorkflowService();
             var controller = new GenericController(dbService, ruleService, wfService, NullLogger<GenericController>.Instance)
             {
                 ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
@@ -149,7 +156,7 @@ public class GenericControllerTests
         try
         {
             var ruleService = new BusinessRuleService(tempFile);
-            var wfService = new WorkflowService();
+            var wfService = CreateWorkflowService();
             var controller = new GenericController(dbService, ruleService, wfService, NullLogger<GenericController>.Instance)
             {
                 ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }

--- a/TheBackend.Tests/WorkflowHistoryServiceTests.cs
+++ b/TheBackend.Tests/WorkflowHistoryServiceTests.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.Configuration;
+using TheBackend.DynamicModels.Workflows;
+using Xunit;
+
+namespace TheBackend.Tests;
+
+public class WorkflowHistoryServiceTests
+{
+    [Fact]
+    public void SaveWorkflow_PersistsToDatabase()
+    {
+        var config = new ConfigurationBuilder().Build();
+        var service = new WorkflowHistoryService(config);
+        var wf = new WorkflowDefinition { WorkflowName = "Test", Steps = new() };
+        service.SaveDefinition(wf);
+        var loaded = service.LoadDefinitions(null);
+        Assert.Contains(loaded, d => d.WorkflowName == "Test");
+    }
+}

--- a/WorkflowNextSteps.md
+++ b/WorkflowNextSteps.md
@@ -1,0 +1,9 @@
+# Next Tasks
+
+1. Implement workflow versioning to allow rollback of definitions.
+2. Extend admin UI to manage workflows stored in the database.
+3. Document database schema updates and migration strategy.
+
+## Instructions
+- Persist all workflow changes using `WorkflowHistoryService`.
+- Update `CHANGELOG.md` with each feature increment.


### PR DESCRIPTION
## Summary
- persist workflow definitions in database and add history tracking
- add WorkflowHistoryService and supporting domain models
- register WorkflowHistoryService in API
- update WorkflowService to use the new service
- cover persistence with new unit tests
- document changes in CHANGELOG and outline next steps

## Testing
- `dotnet format TheBackend.sln`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`


------
https://chatgpt.com/codex/tasks/task_e_6883fe5384448324ab6f7c68297dbdf5