### PR TITLE
Implement workflow versioning with rollback

### DIFF
--- a/AdminUI/src/pages/WorkflowsPage.tsx
+++ b/AdminUI/src/pages/WorkflowsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from 'react';
-import { getWorkflows, getWorkflow, saveWorkflow } from '../services/workflows';
+import { getWorkflows, getWorkflow, saveWorkflow, rollbackWorkflow } from '../services/workflows';
 import type { WorkflowDefinition } from '../types/models';
 
 export default function WorkflowsPage() {
@@ -35,8 +35,13 @@ export default function WorkflowsPage() {
             <ul>
                 {items.map(w => (
                     <li key={w.workflowName} className="flex justify-between">
-                        <span>{w.workflowName}</span>
-                        <button onClick={() => setEditing(w.workflowName)} className="text-blue-600">Edit</button>
+                        <span>{w.workflowName} (v{w.version ?? 1})</span>
+                        <div className="space-x-2">
+                            <button onClick={() => setEditing(w.workflowName)} className="text-blue-600">Edit</button>
+                            {w.version && w.version > 1 && (
+                                <button onClick={() => rollbackWorkflow(w.workflowName, w.version! - 1)} className="text-red-600">Rollback</button>
+                            )}
+                        </div>
                     </li>
                 ))}
             </ul>

--- a/AdminUI/src/services/workflows.ts
+++ b/AdminUI/src/services/workflows.ts
@@ -15,3 +15,7 @@ export async function getWorkflow(name: string): Promise<WorkflowDefinition> {
 export async function saveWorkflow(def: WorkflowDefinition): Promise<void> {
     await api.post('/workflows', def);
 }
+
+export async function rollbackWorkflow(name: string, version: number): Promise<void> {
+    await api.post(`/workflows/${name}/rollback/${version}`);
+}

--- a/AdminUI/src/types/models.ts
+++ b/AdminUI/src/types/models.ts
@@ -35,11 +35,13 @@ export interface Workflow {
 export interface WorkflowDefinition {
     workflowName: string;
     steps: { type: string }[];
+    version?: number;
 }
 
 export interface WorkflowDefinition {
     workflowName: string;
     steps: { type: string }[];
+    version?: number;
 }
 
 export interface ApiResponse<T> {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change log entries stored when workflows are saved.
 ### Changed
 - `WorkflowService` now loads and saves workflows from the database in addition to JSON.
+
+## [0.3.0] - 2025-07-26
+### Added
+- Workflow versioning with ability to rollback definitions.
+### Changed
+- Admin UI displays version and supports rollback.

--- a/TheBackend.Api/Controllers/WorkflowsController.cs
+++ b/TheBackend.Api/Controllers/WorkflowsController.cs
@@ -36,4 +36,13 @@ public class WorkflowsController : ControllerBase
         _service.SaveWorkflow(def);
         return Ok(ApiResponse<object>.Ok(def));
     }
+
+    [HttpPost("{name}/rollback/{version}")]
+    public IActionResult Rollback(string name, int version)
+    {
+        var result = _service.RollbackWorkflow(name, version);
+        return result
+            ? Ok(ApiResponse<string>.Ok($"Rolled back to version {version}"))
+            : NotFound(ApiResponse<string>.Fail("Version not found"));
+    }
 }

--- a/TheBackend.Domain/Models/WorkflowDefinitionRecord.cs
+++ b/TheBackend.Domain/Models/WorkflowDefinitionRecord.cs
@@ -5,5 +5,6 @@ namespace TheBackend.Domain.Models
         public int Id { get; set; }
         public string WorkflowName { get; set; } = string.Empty;
         public string Definition { get; set; } = string.Empty;
+        public int Version { get; set; }
     }
 }

--- a/TheBackend.Domain/Models/WorkflowHistory.cs
+++ b/TheBackend.Domain/Models/WorkflowHistory.cs
@@ -8,5 +8,6 @@ namespace TheBackend.Domain.Models
         public string Definition { get; set; } = string.Empty;
         public string Hash { get; set; } = string.Empty;
         public DateTime Timestamp { get; set; }
+        public int Version { get; set; }
     }
 }

--- a/TheBackend.DynamicModels/Workflows/WorkflowHistoryService.cs
+++ b/TheBackend.DynamicModels/Workflows/WorkflowHistoryService.cs
@@ -9,7 +9,7 @@ public class WorkflowHistoryService
 {
     private readonly DbContextOptions<ModelHistoryDbContext> _options;
 
-    public WorkflowHistoryService(IConfiguration config)
+    public WorkflowHistoryService(IConfiguration config, string? dbName = null)
     {
         var builder = new DbContextOptionsBuilder<ModelHistoryDbContext>();
         var connString = config.GetConnectionString("Default");
@@ -19,7 +19,7 @@ public class WorkflowHistoryService
         else if (provider == "Postgres")
             builder.UseNpgsql(connString);
         else
-            builder.UseInMemoryDatabase("ModelHistory");
+            builder.UseInMemoryDatabase(dbName ?? "ModelHistory");
         _options = builder.Options;
 
         using var ctx = new ModelHistoryDbContext(_options);
@@ -30,32 +30,45 @@ public class WorkflowHistoryService
     {
         using var ctx = new ModelHistoryDbContext(_options);
         var defs = ctx.WorkflowDefinitions
-            .Select(d => JsonConvert.DeserializeObject<WorkflowDefinition>(d.Definition)!)
+            .AsEnumerable()
+            .Select(d =>
+            {
+                var def = JsonConvert.DeserializeObject<WorkflowDefinition>(d.Definition)!;
+                def.Version = d.Version;
+                return def;
+            })
             .ToList();
         if (defs.Count == 0 && file != null && File.Exists(file))
         {
             var json = File.ReadAllText(file);
             defs = JsonConvert.DeserializeObject<List<WorkflowDefinition>>(json) ?? new();
             foreach (var def in defs)
-                SaveDefinition(def);
+            {
+                def.Version = SaveDefinition(def);
+            }
         }
         return defs;
     }
 
-    public void SaveDefinition(WorkflowDefinition def)
+    public int SaveDefinition(WorkflowDefinition def)
     {
         using var ctx = new ModelHistoryDbContext(_options);
         var json = JsonConvert.SerializeObject(def);
         var existing = ctx.WorkflowDefinitions
             .FirstOrDefault(x => x.WorkflowName.Equals(def.WorkflowName, StringComparison.OrdinalIgnoreCase));
+        var version = existing == null ? 1 : existing.Version + 1;
         if (existing == null)
-            ctx.WorkflowDefinitions.Add(new WorkflowDefinitionRecord { WorkflowName = def.WorkflowName, Definition = json });
+            ctx.WorkflowDefinitions.Add(new WorkflowDefinitionRecord { WorkflowName = def.WorkflowName, Definition = json, Version = version });
         else
+        {
             existing.Definition = json;
+            existing.Version = version;
+        }
         ctx.SaveChanges();
+        return version;
     }
 
-    public void RecordChange(WorkflowDefinition def, string action, string hash)
+    public void RecordChange(WorkflowDefinition def, string action, string hash, int version)
     {
         using var ctx = new ModelHistoryDbContext(_options);
         var entry = new WorkflowHistory
@@ -64,10 +77,25 @@ public class WorkflowHistoryService
             Action = action,
             Definition = JsonConvert.SerializeObject(def),
             Hash = hash,
-            Timestamp = DateTime.UtcNow
+            Timestamp = DateTime.UtcNow,
+            Version = version
         };
         ctx.WorkflowHistories.Add(entry);
         ctx.SaveChanges();
+    }
+
+    public WorkflowDefinition? GetVersion(string workflowName, int version)
+    {
+        using var ctx = new ModelHistoryDbContext(_options);
+        var entry = ctx.WorkflowHistories
+            .Where(h => h.WorkflowName == workflowName && h.Version == version)
+            .OrderByDescending(h => h.Timestamp)
+            .FirstOrDefault();
+        if (entry == null)
+            return null;
+        var def = JsonConvert.DeserializeObject<WorkflowDefinition>(entry.Definition)!;
+        def.Version = entry.Version;
+        return def;
     }
 
     public string? GetLastHash()

--- a/TheBackend.Tests/WorkflowHistoryServiceTests.cs
+++ b/TheBackend.Tests/WorkflowHistoryServiceTests.cs
@@ -1,19 +1,43 @@
 using Microsoft.Extensions.Configuration;
 using TheBackend.DynamicModels.Workflows;
 using Xunit;
+using System;
 
 namespace TheBackend.Tests;
 
 public class WorkflowHistoryServiceTests
 {
     [Fact]
-    public void SaveWorkflow_PersistsToDatabase()
+    public void SaveWorkflow_IncrementsVersion()
     {
         var config = new ConfigurationBuilder().Build();
-        var service = new WorkflowHistoryService(config);
+        var service = new WorkflowHistoryService(config, Guid.NewGuid().ToString());
         var wf = new WorkflowDefinition { WorkflowName = "Test", Steps = new() };
-        service.SaveDefinition(wf);
+        var version1 = service.SaveDefinition(wf);
+        Assert.Equal(1, version1);
+        var version2 = service.SaveDefinition(wf);
+        Assert.Equal(2, version2);
         var loaded = service.LoadDefinitions(null);
-        Assert.Contains(loaded, d => d.WorkflowName == "Test");
+        var loadedDef = Assert.Single(loaded, d => d.WorkflowName == "Test");
+        Assert.Equal(2, loadedDef.Version);
+    }
+
+    [Fact]
+    public void RollbackWorkflow_RestoresPreviousVersion()
+    {
+        var config = new ConfigurationBuilder().Build();
+        var history = new WorkflowHistoryService(config, Guid.NewGuid().ToString());
+        var service = new WorkflowService(config, history);
+
+        var wf = new WorkflowDefinition { WorkflowName = "Test", Steps = new() { new WorkflowStep { Type = "A" } } };
+        service.SaveWorkflow(wf);
+        wf.Steps.Add(new WorkflowStep { Type = "B" });
+        service.SaveWorkflow(wf);
+
+        var ok = service.RollbackWorkflow("Test", 1);
+        Assert.True(ok);
+        var current = service.GetWorkflow("Test")!;
+        Assert.Equal(3, current.Version);
+        Assert.Single(current.Steps);
     }
 }

--- a/WorkflowNextSteps.md
+++ b/WorkflowNextSteps.md
@@ -1,6 +1,6 @@
 # Next Tasks
 
-1. Implement workflow versioning to allow rollback of definitions.
+1. ~~Implement workflow versioning to allow rollback of definitions.~~
 2. Extend admin UI to manage workflows stored in the database.
 3. Document database schema updates and migration strategy.
 


### PR DESCRIPTION
## Summary
- add Version fields to workflow history models
- persist version numbers in `WorkflowHistoryService`
- implement workflow rollback support in API and service
- expose version info and rollback in Admin UI
- document changes and update changelog
- add tests for workflow versioning

## Testing
- `dotnet format TheBackend.sln`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`

------
https://chatgpt.com/codex/tasks/task_e_6884021fbd248324ba6bec4080b126c7