### PR TITLE
Fix workflow definition lookup

### DIFF
--- a/TheBackend.DynamicModels/Workflows/WorkflowHistoryService.cs
+++ b/TheBackend.DynamicModels/Workflows/WorkflowHistoryService.cs
@@ -55,7 +55,7 @@ public class WorkflowHistoryService
         using var ctx = new ModelHistoryDbContext(_options);
         var json = JsonConvert.SerializeObject(def);
         var existing = ctx.WorkflowDefinitions
-            .FirstOrDefault(x => x.WorkflowName.Equals(def.WorkflowName, StringComparison.OrdinalIgnoreCase));
+            .FirstOrDefault(x => x.WorkflowName.ToLower() == def.WorkflowName.ToLower());
         var version = existing == null ? 1 : existing.Version + 1;
         if (existing == null)
             ctx.WorkflowDefinitions.Add(new WorkflowDefinitionRecord { WorkflowName = def.WorkflowName, Definition = json, Version = version });


### PR DESCRIPTION
## Summary
- fix case-insensitive workflow definition lookup to avoid EF translation errors

## Testing
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`


------
https://chatgpt.com/codex/tasks/task_e_68840741cf708324810a787ed8f787d1