### PR TITLE
Refactor workflow storage and executors

### DIFF
--- a/TheBackend.Api/Program.cs
+++ b/TheBackend.Api/Program.cs
@@ -13,9 +13,9 @@ builder.Services.AddSingleton<RuleHistoryService>();
 builder.Services.AddSingleton<WorkflowHistoryService>();
 builder.Services.AddSingleton<BusinessRuleService>();
 builder.Services.AddSingleton<WorkflowService>();
-builder.Services.AddTransient<IWorkflowStepExecutor, CreateEntityExecutor>();
-builder.Services.AddTransient<IWorkflowStepExecutor, UpdateEntityExecutor>();
-builder.Services.AddTransient<IWorkflowStepExecutor, ElsaWorkflowExecutor>();
+builder.Services.AddTransient<IWorkflowStepExecutor>(sp => new CreateEntityExecutor<object, object>());
+builder.Services.AddTransient<IWorkflowStepExecutor>(sp => new UpdateEntityExecutor<object, object>(sp.GetRequiredService<ILogger<UpdateEntityExecutor<object, object>>>()));
+builder.Services.AddTransient<IWorkflowStepExecutor>(sp => new ElsaWorkflowExecutor<object>());
 builder.Services.AddSingleton<WorkflowStepExecutorRegistry>();
 builder.Services.AddTransient<ExceptionHandlingMiddleware>();
 

--- a/TheBackend.DynamicModels/Workflows/CreateEntityExecutor.cs
+++ b/TheBackend.DynamicModels/Workflows/CreateEntityExecutor.cs
@@ -5,12 +5,13 @@ using System.Threading.Tasks;
 
 namespace TheBackend.DynamicModels.Workflows;
 
-public class CreateEntityExecutor : IWorkflowStepExecutor
+public class CreateEntityExecutor<TInput, TOutput> : IWorkflowStepExecutor<TInput, TOutput>
+    where TOutput : class
 {
     public string SupportedType => "CreateEntity";
 
-    public async Task<object?> ExecuteAsync(
-        object? inputEntity,
+    public async Task<TOutput?> ExecuteAsync(
+        TInput? inputEntity,
         WorkflowStep step,
         DynamicDbContextService dbContextService,
         IServiceProvider serviceProvider,
@@ -70,7 +71,7 @@ public class CreateEntityExecutor : IWorkflowStepExecutor
         var db = dbContextService.GetDbContext();
         db.Add(newEntity);
         await db.SaveChangesAsync();
-        return newEntity;
+        return (TOutput)newEntity;
     }
 
     private static object? EvaluateFunction(string funcName)

--- a/TheBackend.DynamicModels/Workflows/ElsaWorkflowExecutor.cs
+++ b/TheBackend.DynamicModels/Workflows/ElsaWorkflowExecutor.cs
@@ -11,12 +11,12 @@ using Newtonsoft.Json;
 
 namespace TheBackend.DynamicModels.Workflows;
 
-public class ElsaWorkflowExecutor : IWorkflowStepExecutor
+public class ElsaWorkflowExecutor<TInput> : IWorkflowStepExecutor<TInput, TInput>
 {
     public string SupportedType => "ElsaWorkflow";
 
-    public async Task<object?> ExecuteAsync(
-        object? inputEntity,
+    public async Task<TInput?> ExecuteAsync(
+        TInput? inputEntity,
         WorkflowStep step,
         DynamicDbContextService dbContextService,
         IServiceProvider serviceProvider,

--- a/TheBackend.DynamicModels/Workflows/IWorkflowStepExecutor.cs
+++ b/TheBackend.DynamicModels/Workflows/IWorkflowStepExecutor.cs
@@ -6,9 +6,12 @@ namespace TheBackend.DynamicModels.Workflows;
 public interface IWorkflowStepExecutor
 {
     string SupportedType { get; }
+}
 
-    Task<object?> ExecuteAsync(
-        object? inputEntity,
+public interface IWorkflowStepExecutor<TInput, TOutput> : IWorkflowStepExecutor
+{
+    Task<TOutput?> ExecuteAsync(
+        TInput? input,
         WorkflowStep step,
         DynamicDbContextService dbContextService,
         IServiceProvider serviceProvider,

--- a/TheBackend.DynamicModels/Workflows/UpdateEntityExecutor.cs
+++ b/TheBackend.DynamicModels/Workflows/UpdateEntityExecutor.cs
@@ -7,19 +7,20 @@ using Microsoft.EntityFrameworkCore;
 
 namespace TheBackend.DynamicModels.Workflows;
 
-public class UpdateEntityExecutor : IWorkflowStepExecutor
+public class UpdateEntityExecutor<TInput, TOutput> : IWorkflowStepExecutor<TInput, TOutput>
+    where TOutput : class
 {
-    private readonly ILogger<UpdateEntityExecutor> _logger;
+    private readonly ILogger<UpdateEntityExecutor<TInput, TOutput>> _logger;
 
-    public UpdateEntityExecutor(ILogger<UpdateEntityExecutor> logger)
+    public UpdateEntityExecutor(ILogger<UpdateEntityExecutor<TInput, TOutput>> logger)
     {
         _logger = logger;
     }
 
     public string SupportedType => "UpdateEntity";
 
-    public async Task<object?> ExecuteAsync(
-        object? inputEntity,
+    public async Task<TOutput?> ExecuteAsync(
+        TInput? inputEntity,
         WorkflowStep step,
         DynamicDbContextService dbContextService,
         IServiceProvider serviceProvider,
@@ -100,6 +101,6 @@ public class UpdateEntityExecutor : IWorkflowStepExecutor
         db.Update(entity);
         await db.SaveChangesAsync();
         _logger.LogInformation("Updated {Model} with id {Id}", modelName, idValue);
-        return entity;
+        return (TOutput)entity;
     }
 }

--- a/TheBackend.Tests/GenericControllerTests.cs
+++ b/TheBackend.Tests/GenericControllerTests.cs
@@ -52,10 +52,13 @@ public class GenericControllerTests
     {
         var config = new ConfigurationBuilder().Build();
         var history = new WorkflowHistoryService(config);
-        var executors = new List<IWorkflowStepExecutor> { new CreateEntityExecutor() };
+        var executors = new List<IWorkflowStepExecutor>
+        {
+            new CreateEntityExecutor<object, object>(),
+            new UpdateEntityExecutor<object, object>(NullLogger<UpdateEntityExecutor<object, object>>.Instance)
+        };
         var registry = new WorkflowStepExecutorRegistry(executors);
         return new WorkflowService(
-            config,
             history,
             registry,
             NullLogger<WorkflowService>.Instance);

--- a/TheBackend.Tests/WorkflowHistoryServiceTests.cs
+++ b/TheBackend.Tests/WorkflowHistoryServiceTests.cs
@@ -29,9 +29,12 @@ public class WorkflowHistoryServiceTests
     {
         var config = new ConfigurationBuilder().Build();
         var history = new WorkflowHistoryService(config, Guid.NewGuid().ToString());
-        var executors = new List<IWorkflowStepExecutor> { new CreateEntityExecutor() };
+        var executors = new List<IWorkflowStepExecutor>
+        {
+            new CreateEntityExecutor<object, object>()
+        };
         var registry = new WorkflowStepExecutorRegistry(executors);
-        var service = new WorkflowService(config, history, registry, NullLogger<WorkflowService>.Instance);
+        var service = new WorkflowService(history, registry, NullLogger<WorkflowService>.Instance);
 
         var wf = new WorkflowDefinition { WorkflowName = "Test", Steps = new() { new WorkflowStep { Type = "A" } } };
         service.SaveWorkflow(wf);


### PR DESCRIPTION
## Summary
- remove JSON persistence in `WorkflowService`
- add method `LoadAllCurrentDefinitions` in `WorkflowHistoryService`
- make workflow step executors generic for type-safety
- adapt DI and tests to new executors

## Testing
- `dotnet format TheBackend.sln`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`


------
https://chatgpt.com/codex/tasks/task_e_688432a1c31c83248a4ae0ecd6a4c6d5