### PR TITLE
Add QueryEntity and SendEmail executors

### DIFF
--- a/TheBackend.Api/Program.cs
+++ b/TheBackend.Api/Program.cs
@@ -4,6 +4,8 @@ using TheBackend.DynamicModels;
 using TheBackend.DynamicModels.Workflows;
 using TheBackend.Domain.Models;
 using TheBackend.Api.Middleware;
+using TheBackend.Application.Services;
+using TheBackend.Infrastructure.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddSingleton<ModelDefinitionService>();
@@ -16,6 +18,11 @@ builder.Services.AddSingleton<WorkflowService>();
 builder.Services.AddTransient<IWorkflowStepExecutor>(sp => new CreateEntityExecutor<object, object>());
 builder.Services.AddTransient<IWorkflowStepExecutor>(sp => new UpdateEntityExecutor<object, object>(sp.GetRequiredService<ILogger<UpdateEntityExecutor<object, object>>>()));
 builder.Services.AddTransient<IWorkflowStepExecutor>(sp => new ElsaWorkflowExecutor<object>());
+builder.Services.AddTransient<IWorkflowStepExecutor>(sp => new QueryEntityExecutor<object, object>());
+builder.Services.AddTransient<IWorkflowStepExecutor>(sp => new SendEmailExecutor<object>(sp.GetRequiredService<IEmailService>()));
+builder.Services.AddTransient(typeof(IWorkflowStepExecutor<,>), typeof(QueryEntityExecutor<,>));
+builder.Services.AddTransient(typeof(IWorkflowStepExecutor<,>), typeof(SendEmailExecutor<>));
+builder.Services.AddTransient<IEmailService, LoggingEmailService>();
 builder.Services.AddSingleton<WorkflowStepExecutorRegistry>();
 builder.Services.AddTransient<ExceptionHandlingMiddleware>();
 

--- a/TheBackend.Application/Services/IEmailService.cs
+++ b/TheBackend.Application/Services/IEmailService.cs
@@ -1,0 +1,6 @@
+namespace TheBackend.Application.Services;
+
+public interface IEmailService
+{
+    Task SendEmailAsync(string to, string subject, string body);
+}

--- a/TheBackend.DynamicModels/TheBackend.DynamicModels.csproj
+++ b/TheBackend.DynamicModels/TheBackend.DynamicModels.csproj
@@ -30,9 +30,11 @@
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="Elsa.Workflows.Runtime" Version="3.4.2" />
     <PackageReference Include="Elsa.Workflows.Management" Version="3.4.2" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.6.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TheBackend.Domain\TheBackend.Domain.csproj" />
+    <ProjectReference Include="..\TheBackend.Application\TheBackend.Application.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="TheBackend\DynamicModels\" />

--- a/TheBackend.DynamicModels/Workflows/QueryEntityExecutor.cs
+++ b/TheBackend.DynamicModels/Workflows/QueryEntityExecutor.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using System.Linq.Dynamic.Core;
+
+namespace TheBackend.DynamicModels.Workflows;
+
+public class QueryEntityExecutor<TInput, TOutput> : IWorkflowStepExecutor<TInput, IEnumerable<TOutput>>
+    where TOutput : class
+{
+    public string SupportedType => "QueryEntity";
+
+    public async Task<IEnumerable<TOutput>?> ExecuteAsync(
+        TInput? input,
+        WorkflowStep step,
+        DynamicDbContextService dbContextService,
+        IServiceProvider serviceProvider,
+        Dictionary<string, object> variables)
+    {
+        var modelName = step.GetParameterValue<string>("ModelName");
+        if (string.IsNullOrWhiteSpace(modelName))
+            throw new InvalidOperationException("ModelName parameter missing");
+
+        var filter = step.GetParameterValue<string>("Filter");
+        var db = dbContextService.GetDbContext();
+        var set = db.Set<TOutput>();
+        IQueryable<TOutput> query = set;
+        if (!string.IsNullOrWhiteSpace(filter))
+            query = query.Where(filter);
+        return await query.ToListAsync();
+    }
+}

--- a/TheBackend.DynamicModels/Workflows/SendEmailExecutor.cs
+++ b/TheBackend.DynamicModels/Workflows/SendEmailExecutor.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using TheBackend.Application.Services;
+
+namespace TheBackend.DynamicModels.Workflows;
+
+public class SendEmailExecutor<TInput> : IWorkflowStepExecutor<TInput, bool>
+{
+    private readonly IEmailService _emailService;
+
+    public SendEmailExecutor(IEmailService emailService)
+    {
+        _emailService = emailService;
+    }
+
+    public string SupportedType => "SendEmail";
+
+    public async Task<bool> ExecuteAsync(
+        TInput? input,
+        WorkflowStep step,
+        DynamicDbContextService dbContextService,
+        IServiceProvider serviceProvider,
+        Dictionary<string, object> variables)
+    {
+        var to = step.GetParameterValue<string>("To") ?? throw new InvalidOperationException("To parameter missing");
+        var subject = step.GetParameterValue<string>("Subject") ?? string.Empty;
+        var body = step.GetParameterValue<string>("Body") ?? string.Empty;
+        await _emailService.SendEmailAsync(to, subject, body);
+        return true;
+    }
+}

--- a/TheBackend.DynamicModels/Workflows/WorkflowStepExecutorRegistry.cs
+++ b/TheBackend.DynamicModels/Workflows/WorkflowStepExecutorRegistry.cs
@@ -1,28 +1,32 @@
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace TheBackend.DynamicModels.Workflows;
 
 public class WorkflowStepExecutorRegistry
 {
-    private readonly Dictionary<string, IWorkflowStepExecutor> _executors = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, Type> _executorTypes = new(StringComparer.OrdinalIgnoreCase);
+    private readonly IServiceProvider _provider;
 
-    public WorkflowStepExecutorRegistry(IEnumerable<IWorkflowStepExecutor> executors)
+    public WorkflowStepExecutorRegistry(IEnumerable<IWorkflowStepExecutor> executors, IServiceProvider provider)
     {
+        _provider = provider;
         foreach (var executor in executors)
         {
-            _executors[executor.SupportedType] = executor;
+            _executorTypes[executor.SupportedType] = executor.GetType();
         }
     }
 
     public void Register(IWorkflowStepExecutor executor)
     {
-        _executors[executor.SupportedType] = executor;
+        _executorTypes[executor.SupportedType] = executor.GetType();
     }
 
     public IWorkflowStepExecutor? GetExecutor(string type)
     {
-        _executors.TryGetValue(type, out var executor);
-        return executor;
+        if (!_executorTypes.TryGetValue(type, out var executorType))
+            return null;
+        return (IWorkflowStepExecutor)_provider.GetRequiredService(executorType);
     }
 }

--- a/TheBackend.DynamicModels/Workflows/WorkflowStepExtensions.cs
+++ b/TheBackend.DynamicModels/Workflows/WorkflowStepExtensions.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Linq;
+
+namespace TheBackend.DynamicModels.Workflows;
+
+public static class WorkflowStepExtensions
+{
+    public static T? GetParameterValue<T>(this WorkflowStep step, string key)
+    {
+        var param = step.Parameters.FirstOrDefault(p =>
+            p.Key.Equals(key, StringComparison.OrdinalIgnoreCase));
+        var value = param?.GetTypedValue();
+        if (value is T t) return t;
+        if (value == null) return default;
+        return (T)Convert.ChangeType(value, typeof(T));
+    }
+}

--- a/TheBackend.Infrastructure/Services/LoggingEmailService.cs
+++ b/TheBackend.Infrastructure/Services/LoggingEmailService.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Logging;
+using TheBackend.Application.Services;
+
+namespace TheBackend.Infrastructure.Services;
+
+public class LoggingEmailService : IEmailService
+{
+    private readonly ILogger<LoggingEmailService> _logger;
+
+    public LoggingEmailService(ILogger<LoggingEmailService> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task SendEmailAsync(string to, string subject, string body)
+    {
+        _logger.LogInformation("Sending email to {To} with subject {Subject}", to, subject);
+        // In real implementation, send email via SMTP or API
+        return Task.CompletedTask;
+    }
+}

--- a/TheBackend.Tests/GenericControllerTests.cs
+++ b/TheBackend.Tests/GenericControllerTests.cs
@@ -8,6 +8,7 @@ using TheBackend.DynamicModels.Workflows;
 using Newtonsoft.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using System.Collections.Generic;
 
@@ -57,7 +58,11 @@ public class GenericControllerTests
             new CreateEntityExecutor<object, object>(),
             new UpdateEntityExecutor<object, object>(NullLogger<UpdateEntityExecutor<object, object>>.Instance)
         };
-        var registry = new WorkflowStepExecutorRegistry(executors);
+        var services = new ServiceCollection();
+        foreach (var ex in executors)
+            services.AddSingleton(ex.GetType(), ex);
+        var provider = services.BuildServiceProvider();
+        var registry = new WorkflowStepExecutorRegistry(executors, provider);
         return new WorkflowService(
             history,
             registry,

--- a/TheBackend.Tests/WorkflowHistoryServiceTests.cs
+++ b/TheBackend.Tests/WorkflowHistoryServiceTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Configuration;
 using TheBackend.DynamicModels.Workflows;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using System;
 using System.Collections.Generic;
@@ -36,7 +37,11 @@ public class WorkflowHistoryServiceTests
         {
             new CreateEntityExecutor<object, object>()
         };
-        var registry = new WorkflowStepExecutorRegistry(executors);
+        var services = new ServiceCollection();
+        foreach (var ex in executors)
+            services.AddSingleton(ex.GetType(), ex);
+        var provider = services.BuildServiceProvider();
+        var registry = new WorkflowStepExecutorRegistry(executors, provider);
         var service = new WorkflowService(history, registry, NullLogger<WorkflowService>.Instance);
 
         var wf = new WorkflowDefinition { WorkflowName = "Test", Steps = new() { new WorkflowStep { Type = "A" } } };

--- a/TheBackend.Tests/WorkflowServiceTests.cs
+++ b/TheBackend.Tests/WorkflowServiceTests.cs
@@ -40,7 +40,10 @@ public class WorkflowServiceTests
     {
         var config = new ConfigurationBuilder().Build();
         var history = new WorkflowHistoryService(config, Guid.NewGuid().ToString());
-        var registry = new WorkflowStepExecutorRegistry(new[] { executor });
+        var services = new ServiceCollection();
+        services.AddSingleton(executor.GetType(), executor);
+        var provider = services.BuildServiceProvider();
+        var registry = new WorkflowStepExecutorRegistry(new[] { executor }, provider);
         return new WorkflowService(history, registry, NullLogger<WorkflowService>.Instance);
     }
 


### PR DESCRIPTION
## Summary
- create `QueryEntityExecutor` to query entities with dynamic filter
- add `SendEmailExecutor` that uses `IEmailService`
- implement `LoggingEmailService` and `IEmailService` interface
- update DI registrations for new executors
- extend workflow registry to resolve executors from DI
- update unit tests for new registry constructor

## Testing
- `dotnet format TheBackend.sln --no-restore`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`

------
https://chatgpt.com/codex/tasks/task_e_68849ab1c54083248951505aed7b9d02