### PR TITLE
Fix SendEmailExecutor generic registration

### DIFF
--- a/TheBackend.Api/Program.cs
+++ b/TheBackend.Api/Program.cs
@@ -20,7 +20,7 @@ builder.Services.AddTransient<IWorkflowStepExecutor>(sp => new CreateEntityExecu
 builder.Services.AddTransient<IWorkflowStepExecutor>(sp => new UpdateEntityExecutor<object, object>(sp.GetRequiredService<ILogger<UpdateEntityExecutor<object, object>>>()));
 builder.Services.AddTransient<IWorkflowStepExecutor>(sp => new ElsaWorkflowExecutor<object>());
 builder.Services.AddTransient<IWorkflowStepExecutor>(sp => new QueryEntityExecutor<object, object>());
-builder.Services.AddTransient<IWorkflowStepExecutor<object, bool>>(sp => new SendEmailExecutor(sp.GetRequiredService<IEmailService>()));
+builder.Services.AddTransient<IWorkflowStepExecutor<object, bool>>(sp => new SendEmailExecutor<object>(sp.GetRequiredService<IEmailService>()));
 builder.Services.AddTransient(typeof(IWorkflowStepExecutor<,>), typeof(QueryEntityExecutor<,>));
 builder.Services.AddTransient<IEmailService, LoggingEmailService>();
 builder.Services.AddSingleton<WorkflowStepExecutorRegistry>();

--- a/TheBackend.DynamicModels/Workflows/SendEmailExecutor.cs
+++ b/TheBackend.DynamicModels/Workflows/SendEmailExecutor.cs
@@ -5,7 +5,7 @@ using TheBackend.Application.Services;
 
 namespace TheBackend.DynamicModels.Workflows;
 
-public class SendEmailExecutor : IWorkflowStepExecutor<object, bool>
+public class SendEmailExecutor<TInput> : IWorkflowStepExecutor<TInput, bool>
 {
     private readonly IEmailService _emailService;
 
@@ -17,7 +17,7 @@ public class SendEmailExecutor : IWorkflowStepExecutor<object, bool>
     public string SupportedType => "SendEmail";
 
     public async Task<bool> ExecuteAsync(
-        object? input,
+        TInput? input,
         WorkflowStep step,
         DynamicDbContextService dbContextService,
         IServiceProvider serviceProvider,


### PR DESCRIPTION
## Summary
- make `SendEmailExecutor` generic so it implements `IWorkflowStepExecutor<TInput, bool>`
- register `SendEmailExecutor<object>` in `Program.cs`

## Testing
- `dotnet format TheBackend.sln --no-restore`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`


------
https://chatgpt.com/codex/tasks/task_e_6884c2626c7c832498d0d689aae44461