### PR TITLE
Fix workflow designer addTrigger and add features endpoint

### DIFF
--- a/AdminUI/src/components/WorkflowEditor.tsx
+++ b/AdminUI/src/components/WorkflowEditor.tsx
@@ -27,9 +27,17 @@ export function WorkflowEditor({ initialWorkflow, onSave }: Props) {
         onSave(def);
     };
 
-    const addTrigger = () => {
+    const addTrigger = async () => {
         if (!designerRef.current) return;
-        designerRef.current.addActivity({ type: 'HttpEndpoint', properties: { path: '/triggers/my-event', methods: ['POST'] } });
+
+        // Obtain the underlying flowchart element which exposes the addActivity API.
+        const chart = await designerRef.current.getFlowchart();
+        if (!chart) return;
+
+        await chart.addActivity({
+            type: 'HttpEndpoint',
+            properties: { path: '/triggers/my-event', methods: ['POST'] }
+        });
     };
 
     return (

--- a/TheBackend.Api/Controllers/FeaturesController.cs
+++ b/TheBackend.Api/Controllers/FeaturesController.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace TheBackend.Api.Controllers
+{
+    [ApiController]
+    [Route("elsa/api/v1/features")]
+    public class FeaturesController : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult Get()
+        {
+            // Return an empty feature list so Elsa Studio loads without errors.
+            return Ok(new { features = new string[0] });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- support the flowchart API when adding triggers
- stub `/elsa/api/v1/features` endpoint so the Elsa dashboard loads

## Testing
- `dotnet format TheBackend.sln --no-restore -v diag`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6884c57745f0832492a57266cd24aecc