### PR TITLE
Support workflow parameters as JSON objects

### DIFF
--- a/TheBackend.DynamicModels/Workflows/ParameterListJsonConverter.cs
+++ b/TheBackend.DynamicModels/Workflows/ParameterListJsonConverter.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace TheBackend.DynamicModels.Workflows;
+
+public class ParameterListJsonConverter : JsonConverter<List<Parameter>>
+{
+    public override List<Parameter> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.StartArray)
+        {
+            return JsonSerializer.Deserialize<List<Parameter>>(ref reader, options) ?? new();
+        }
+
+        if (reader.TokenType == JsonTokenType.StartObject)
+        {
+            using var doc = JsonDocument.ParseValue(ref reader);
+            var list = new List<Parameter>();
+            foreach (var prop in doc.RootElement.EnumerateObject())
+            {
+                switch (prop.Value.ValueKind)
+                {
+                    case JsonValueKind.Number:
+                        list.Add(new Parameter { Key = prop.Name, ValueType = "int", Value = prop.Value.GetRawText() });
+                        break;
+                    case JsonValueKind.True:
+                    case JsonValueKind.False:
+                        list.Add(new Parameter { Key = prop.Name, ValueType = "bool", Value = prop.Value.GetBoolean().ToString() });
+                        break;
+                    case JsonValueKind.String:
+                        list.Add(new Parameter { Key = prop.Name, ValueType = "string", Value = prop.Value.GetString() ?? string.Empty });
+                        break;
+                    default:
+                        list.Add(new Parameter { Key = prop.Name, ValueType = "json", Value = prop.Value.GetRawText() });
+                        break;
+                }
+            }
+            return list;
+        }
+
+        return new List<Parameter>();
+    }
+
+    public override void Write(Utf8JsonWriter writer, List<Parameter> value, JsonSerializerOptions options)
+    {
+        JsonSerializer.Serialize(writer, value, options);
+    }
+}

--- a/TheBackend.DynamicModels/Workflows/WorkflowModels.cs
+++ b/TheBackend.DynamicModels/Workflows/WorkflowModels.cs
@@ -1,3 +1,6 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
 namespace TheBackend.DynamicModels.Workflows;
 
 public class WorkflowDefinition
@@ -19,6 +22,8 @@ public class GlobalVariable
     {
         "int" => int.TryParse(Value, out var i) ? i : Value,
         "bool" => bool.TryParse(Value, out var b) ? b : Value,
+        "double" => double.TryParse(Value, out var d) ? d : Value,
+        "json" => JsonSerializer.Deserialize<object>(Value),
         _ => Value,
     };
 }
@@ -26,6 +31,7 @@ public class GlobalVariable
 public class WorkflowStep
 {
     public string Type { get; set; } = string.Empty;
+    [JsonConverter(typeof(ParameterListJsonConverter))]
     public List<Parameter> Parameters { get; set; } = new();
     public string? Condition { get; set; }
     public string? OnError { get; set; }
@@ -42,6 +48,8 @@ public class Parameter
     {
         "int" => int.TryParse(Value, out var i) ? i : Value,
         "bool" => bool.TryParse(Value, out var b) ? b : Value,
+        "double" => double.TryParse(Value, out var d) ? d : Value,
+        "json" => JsonSerializer.Deserialize<object>(Value),
         _ => Value,
     };
 }


### PR DESCRIPTION
## Summary
- allow workflow parameters to be supplied as an object or list
- parse `json` and `double` parameter types
- deserialize mapping lists from JSON in executors

## Testing
- `dotnet format TheBackend.sln`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`


------
https://chatgpt.com/codex/tasks/task_e_6884e4822da48324b87b091d2c3d7d4b