### PR TITLE
Fix step executor return casting

### DIFF
--- a/TheBackend.DynamicModels/Workflows/WorkflowService.cs
+++ b/TheBackend.DynamicModels/Workflows/WorkflowService.cs
@@ -127,7 +127,7 @@ public class WorkflowService
                 }
 
                 current = await HandleStepError(
-                    () => ((dynamic)executor).ExecuteAsync(
+                    async () => (object?)await ((dynamic)executor).ExecuteAsync(
                         (dynamic)current,
                         step,
                         dbContextService,


### PR DESCRIPTION
## Summary
- ensure workflow step execution results are cast to `object` before handling errors

## Testing
- `dotnet format TheBackend.sln`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`


------
https://chatgpt.com/codex/tasks/task_e_68862e82e2308324bee4820d5a3893ff