### PR TITLE
Enable global and input placeholder resolution for workflow emails

### DIFF
--- a/TheBackend.DynamicModels/Workflows/SendEmailExecutor.cs
+++ b/TheBackend.DynamicModels/Workflows/SendEmailExecutor.cs
@@ -23,9 +23,10 @@ public class SendEmailExecutor<TInput> : IWorkflowStepExecutor<TInput, bool>
         IServiceProvider serviceProvider,
         Dictionary<string, object> variables)
     {
-        var to = step.GetParameterValue<string>("To") ?? throw new InvalidOperationException("To parameter missing");
-        var subject = step.GetParameterValue<string>("Subject") ?? string.Empty;
-        var body = step.GetParameterValue<string>("Body") ?? string.Empty;
+        var to = step.GetResolvedString("To", input, variables)
+                 ?? throw new InvalidOperationException("To parameter missing");
+        var subject = step.GetResolvedString("Subject", input, variables) ?? string.Empty;
+        var body = step.GetResolvedString("Body", input, variables) ?? string.Empty;
         await _emailService.SendEmailAsync(to, subject, body);
         return true;
     }

--- a/TheBackend.DynamicModels/Workflows/WorkflowStepExtensions.cs
+++ b/TheBackend.DynamicModels/Workflows/WorkflowStepExtensions.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace TheBackend.DynamicModels.Workflows;
 
@@ -13,5 +15,51 @@ public static class WorkflowStepExtensions
         if (value is T t) return t;
         if (value == null) return default;
         return (T)Convert.ChangeType(value, typeof(T));
+    }
+
+    public static string? GetResolvedString(
+        this WorkflowStep step,
+        string key,
+        object? input,
+        Dictionary<string, object> variables)
+    {
+        var raw = step.GetParameterValue<string>(key);
+        return raw == null ? null : ResolvePlaceholders(raw, input, variables);
+    }
+
+    private static string ResolvePlaceholders(
+        string template,
+        object? input,
+        Dictionary<string, object> variables)
+    {
+        return Regex.Replace(
+            template,
+            "\\{\\{(Global|Input)\\.([^\\}]+)\\}\\}",
+            m =>
+            {
+                var type = m.Groups[1].Value;
+                var name = m.Groups[2].Value;
+                if (type.Equals("Global", StringComparison.OrdinalIgnoreCase) &&
+                    variables.TryGetValue(name, out var val))
+                    return val?.ToString() ?? string.Empty;
+                if (type.Equals("Input", StringComparison.OrdinalIgnoreCase))
+                    return GetInputValue(input, name)?.ToString() ?? string.Empty;
+                return m.Value;
+            });
+    }
+
+    private static object? GetInputValue(object? input, string propertyPath)
+    {
+        if (input == null) return null;
+        var current = input;
+        foreach (var part in propertyPath.Split('.'))
+        {
+            var prop = current.GetType().GetProperty(part);
+            if (prop == null) return null;
+            current = prop.GetValue(current);
+            if (current == null) return null;
+        }
+
+        return current;
     }
 }


### PR DESCRIPTION
## Summary
- add helper to resolve `{{Global.*}}` and `{{Input.*}}` placeholders
- update SendEmail step to substitute variables before sending

## Testing
- `dotnet format TheBackend.sln`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`


------
https://chatgpt.com/codex/tasks/task_e_68863d62e800832497c14c0f975404d1