### PR TITLE
Improve missing entity error handling

### DIFF
--- a/TheBackend.Api/Middleware/ExceptionHandlingMiddleware.cs
+++ b/TheBackend.Api/Middleware/ExceptionHandlingMiddleware.cs
@@ -32,6 +32,15 @@ public class ExceptionHandlingMiddleware : IMiddleware
             context.Response.StatusCode = StatusCodes.Status400BadRequest;
             await context.Response.WriteAsJsonAsync(response);
         }
+        catch (KeyNotFoundException nfEx)
+        {
+            _logger.LogWarning(nfEx, "Entity not found");
+            var response = ApiResponse<object>.Fail(nfEx.Message);
+            response.Meta.TraceId = context.TraceIdentifier;
+            response.Meta.StatusCode = StatusCodes.Status404NotFound;
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            await context.Response.WriteAsJsonAsync(response);
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Unhandled exception");


### PR DESCRIPTION
## Summary
- catch `KeyNotFoundException` in `ExceptionHandlingMiddleware`
- return 404 responses for missing entities instead of generic 500 error

## Testing
- `dotnet format TheBackend.sln`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`


------
https://chatgpt.com/codex/tasks/task_e_68868a0fced4832492625568c507a518