### PR TITLE
Add workflow validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,3 +83,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Mappings` parameter edited via multiline text area.
 - Message shown when no steps exist.
 - Step headers display the step type.
+
+## [0.13.0] - 2025-08-01
+### Added
+- Workflow validation prevents invalid steps and parameters.
+### Changed
+- Tests updated for new validation logic.
+

--- a/TheBackend.Tests/WorkflowHistoryServiceTests.cs
+++ b/TheBackend.Tests/WorkflowHistoryServiceTests.cs
@@ -44,9 +44,30 @@ public class WorkflowHistoryServiceTests
         var registry = new WorkflowStepExecutorRegistry(executors, provider);
         var service = new WorkflowService(history, registry, NullLogger<WorkflowService>.Instance);
 
-        var wf = new WorkflowDefinition { WorkflowName = "Test", Steps = new() { new WorkflowStep { Type = "A" } } };
+        var wf = new WorkflowDefinition
+        {
+            WorkflowName = "Test",
+            Steps = new()
+            {
+                new WorkflowStep
+                {
+                    Type = "CreateEntity",
+                    Parameters = new List<Parameter>
+                    {
+                        new() { Key = "ModelName", ValueType = "string", Value = "X" }
+                    }
+                }
+            }
+        };
         service.SaveWorkflow(wf);
-        wf.Steps.Add(new WorkflowStep { Type = "B" });
+        wf.Steps.Add(new WorkflowStep
+        {
+            Type = "CreateEntity",
+            Parameters = new List<Parameter>
+            {
+                new() { Key = "ModelName", ValueType = "string", Value = "X" }
+            }
+        });
         service.SaveWorkflow(wf);
 
         service.RollbackWorkflow("Test", 1);


### PR DESCRIPTION
## Summary
- validate workflow definitions before saving
- update history and service tests for validations
- document workflow validation in CHANGELOG

## Testing
- `dotnet format TheBackend.sln --no-restore`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`


------
https://chatgpt.com/codex/tasks/task_e_68869512fc84832490061139d19bc6e8