### PR TITLE
Add strict workflow validations

### DIFF
--- a/TheBackend.Tests/GenericControllerTests.cs
+++ b/TheBackend.Tests/GenericControllerTests.cs
@@ -67,7 +67,8 @@ public class GenericControllerTests
         return new WorkflowService(
             history,
             registry,
-            NullLogger<WorkflowService>.Instance);
+            NullLogger<WorkflowService>.Instance,
+            new ModelDefinitionService());
     }
 
     [Fact]
@@ -221,7 +222,17 @@ public class GenericControllerTests
             var wf = new WorkflowDefinition
             {
                 WorkflowName = $"{nameof(TestEntity)}.AfterUpdate",
-                Steps = new List<WorkflowStep> { new() { Type = executor.SupportedType } },
+                Steps = new List<WorkflowStep>
+                {
+                    new()
+                    {
+                        Type = executor.SupportedType,
+                        Parameters = new List<Parameter>
+                        {
+                            new() { Key = "ModelName", ValueType = "string", Value = "TestEntity" }
+                        }
+                    }
+                },
                 IsTransactional = false
             };
             wfService.SaveWorkflow(wf);
@@ -260,7 +271,17 @@ public class GenericControllerTests
             var wf = new WorkflowDefinition
             {
                 WorkflowName = $"{nameof(TestEntity)}.AfterDelete",
-                Steps = new List<WorkflowStep> { new() { Type = executor.SupportedType } },
+                Steps = new List<WorkflowStep>
+                {
+                    new()
+                    {
+                        Type = executor.SupportedType,
+                        Parameters = new List<Parameter>
+                        {
+                            new() { Key = "ModelName", ValueType = "string", Value = "TestEntity" }
+                        }
+                    }
+                },
                 IsTransactional = false
             };
             wfService.SaveWorkflow(wf);
@@ -299,7 +320,7 @@ public class TestDbContext : DbContext
 
 public class CountingExecutor : IWorkflowStepExecutor<object, object>
 {
-    public string SupportedType => "Count";
+    public string SupportedType => "CreateEntity";
     public int Count { get; private set; }
 
     public Task<object?> ExecuteAsync(

--- a/TheBackend.Tests/WorkflowHistoryServiceTests.cs
+++ b/TheBackend.Tests/WorkflowHistoryServiceTests.cs
@@ -42,7 +42,7 @@ public class WorkflowHistoryServiceTests
             services.AddSingleton(ex.GetType(), ex);
         var provider = services.BuildServiceProvider();
         var registry = new WorkflowStepExecutorRegistry(executors, provider);
-        var service = new WorkflowService(history, registry, NullLogger<WorkflowService>.Instance);
+        var service = new WorkflowService(history, registry, NullLogger<WorkflowService>.Instance, new ModelDefinitionService());
 
         var wf = new WorkflowDefinition
         {
@@ -54,7 +54,7 @@ public class WorkflowHistoryServiceTests
                     Type = "CreateEntity",
                     Parameters = new List<Parameter>
                     {
-                        new() { Key = "ModelName", ValueType = "string", Value = "X" }
+                        new() { Key = "ModelName", ValueType = "string", Value = "User" }
                     }
                 }
             }
@@ -65,7 +65,7 @@ public class WorkflowHistoryServiceTests
             Type = "CreateEntity",
             Parameters = new List<Parameter>
             {
-                new() { Key = "ModelName", ValueType = "string", Value = "X" }
+                new() { Key = "ModelName", ValueType = "string", Value = "User" }
             }
         });
         service.SaveWorkflow(wf);


### PR DESCRIPTION
## Summary
- enforce step type and parameter validation in workflow service
- ensure model names exist when available
- validate global variables and output variables
- update tests and executors for new restrictions

## Testing
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`

------
https://chatgpt.com/codex/tasks/task_e_688697d296b4832497f1419aa3c18315