### PR TITLE
Add basic theming and button component

### DIFF
--- a/AdminUI/src/components/Button.tsx
+++ b/AdminUI/src/components/Button.tsx
@@ -1,0 +1,23 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+    variant?: 'primary' | 'secondary' | 'danger';
+    children: ReactNode;
+}
+
+export function Button({ variant = 'primary', className = '', children, ...props }: ButtonProps) {
+    const styles: Record<'primary' | 'secondary' | 'danger', string> = {
+        primary: 'bg-primary text-white hover:bg-primary-dark',
+        secondary: 'bg-secondary text-gray-800 hover:bg-secondary-dark dark:text-white',
+        danger: 'bg-red-600 text-white hover:bg-red-700',
+    };
+
+    return (
+        <button
+            className={`px-3 py-1 rounded ${styles[variant]} ${className}`.trim()}
+            {...props}
+        >
+            {children}
+        </button>
+    );
+}

--- a/AdminUI/src/components/Header.tsx
+++ b/AdminUI/src/components/Header.tsx
@@ -1,26 +1,14 @@
-import { useState } from 'react';
+import { useTheme } from '../theme';
 
 export function Header() {
-    const [dark, setDark] = useState(
-        window.matchMedia('(prefers-color-scheme: dark)').matches
-    );
-
-    const toggle = () => {
-        const root = document.documentElement;
-        if (dark) {
-            root.classList.remove('dark');
-        } else {
-            root.classList.add('dark');
-        }
-        setDark(!dark);
-    };
+    const { theme, toggleTheme } = useTheme();
 
     return (
         <header className="h-12 flex items-center justify-between px-4 border-b border-gray-200 dark:border-neutral-700">
             <h1 className="text-lg font-semibold">AdminUI</h1>
             <div className="flex items-center gap-3">
-                <button onClick={toggle} className="px-2 py-1 rounded bg-gray-200 dark:bg-neutral-700">
-                    {dark ? 'Light' : 'Dark'}
+                <button onClick={toggleTheme} className="px-2 py-1 rounded bg-gray-200 dark:bg-neutral-700">
+                    {theme === 'dark' ? 'Light' : 'Dark'}
                 </button>
                 <div className="w-8 h-8 rounded-full bg-gray-400" />
             </div>

--- a/AdminUI/src/components/RuleEditorForm.tsx
+++ b/AdminUI/src/components/RuleEditorForm.tsx
@@ -1,4 +1,5 @@
 import { Rule, Workflow } from '../types/models';
+import { Button } from './Button';
 
 interface Props {
     workflow: Workflow;
@@ -69,12 +70,7 @@ export function RuleEditorForm({ workflow, onChange, suggestions }: Props) {
                     <option key={s} value={`entity.${s}`} />
                 ))}
             </datalist>
-            <button
-                onClick={addRule}
-                className="px-2 py-1 rounded bg-gray-300 dark:bg-neutral-700"
-            >
-                Add Rule
-            </button>
+            <Button variant="secondary" onClick={addRule}>Add Rule</Button>
         </div>
     );
 }

--- a/AdminUI/src/components/WorkflowEditorForm.tsx
+++ b/AdminUI/src/components/WorkflowEditorForm.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { stepTypes, valueTypes, workflowEvents } from '../types/models';
 import { getModels } from '../services/models';
 import type { WorkflowDefinition, WorkflowStep, Parameter } from '../types/models';
+import { Button } from './Button';
 
 const stepDescriptions: Record<string, string> = {
     CreateEntity: 'Create a new record for the selected model.',
@@ -319,13 +320,13 @@ export default function WorkflowEditorForm({ workflow, onChange }: Props) {
                     </div>
                 ))}
                 <div className="flex gap-2">
-                    <button onClick={addStep} className="px-3 py-1 rounded bg-gray-300 dark:bg-neutral-700">Add Step</button>
-                    <button
+                    <Button variant="secondary" onClick={addStep}>Add Step</Button>
+                    <Button
+                        variant="secondary"
                         onClick={() => navigator.clipboard.writeText(JSON.stringify(workflow, null, 2))}
-                        className="px-3 py-1 rounded bg-gray-300 dark:bg-neutral-700"
                     >
                         Copy JSON
-                    </button>
+                    </Button>
                 </div>
             </div>
         </div>

--- a/AdminUI/src/index.css
+++ b/AdminUI/src/index.css
@@ -1,2 +1,9 @@
-@import "tailwindcss";
-@tailwind utilities;
+@import "tailwindcss/base";
+@import "tailwindcss/components";
+@import "tailwindcss/utilities";
+
+@layer base {
+    body {
+        @apply bg-white dark:bg-neutral-900 text-gray-900 dark:text-gray-100;
+    }
+}

--- a/AdminUI/src/main.tsx
+++ b/AdminUI/src/main.tsx
@@ -3,13 +3,16 @@ import { createRoot } from 'react-dom/client';
 import App from './App';
 import './index.css';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from './theme';
 
 const queryClient = new QueryClient();
 
 createRoot(document.getElementById('root')!).render(
     <StrictMode>
         <QueryClientProvider client={queryClient}>
-            <App />
+            <ThemeProvider>
+                <App />
+            </ThemeProvider>
         </QueryClientProvider>
     </StrictMode>
 );

--- a/AdminUI/src/pages/RulesPage.tsx
+++ b/AdminUI/src/pages/RulesPage.tsx
@@ -3,6 +3,7 @@ import { getWorkflows, saveWorkflow } from '../services/rules';
 import { getModels } from '../services/models';
 import type { Workflow } from '../types/models';
 import { RuleEditorForm } from '../components/RuleEditorForm';
+import { Button } from '../components/Button';
 
 export default function RulesPage() {
     const [workflows, setWorkflows] = useState<Workflow[]>([]);
@@ -82,9 +83,7 @@ export default function RulesPage() {
         <div className="space-y-4 p-4">
             <div className="flex items-center justify-between">
                 <h2 className="text-xl font-semibold">Rules</h2>
-                <button onClick={() => startEdit()} className="px-3 py-1 rounded bg-blue-600 text-white">
-                    New
-                </button>
+                <Button onClick={() => startEdit()}>New</Button>
             </div>
             <ul className="space-y-1">
                 {/* Now, workflows is guaranteed to be an array, so .length and .map are safe */}
@@ -107,20 +106,19 @@ export default function RulesPage() {
                     <h3 className="text-lg font-semibold">{editing.workflowName ? `Editing: ${editing.workflowName}` : 'New Workflow'}</h3>
                     <RuleEditorForm workflow={editing} onChange={setEditing} suggestions={suggestions} />
                     <div className="flex justify-end space-x-2">
-                        <button
+                        <Button
+                            variant="secondary"
                             onClick={() => setEditing(null)}
-                            className="px-4 py-2 rounded bg-gray-300 text-gray-800 hover:bg-gray-400"
                             disabled={isSaving}
                         >
                             Cancel
-                        </button>
-                        <button
+                        </Button>
+                        <Button
                             onClick={save}
-                            className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
                             disabled={isSaving}
                         >
                             {isSaving ? 'Saving...' : 'Save'}
-                        </button>
+                        </Button>
                     </div>
                 </div>
             )}

--- a/AdminUI/src/pages/WorkflowsPage.tsx
+++ b/AdminUI/src/pages/WorkflowsPage.tsx
@@ -13,6 +13,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import WorkflowEditorForm, { defaultParams } from '../components/WorkflowEditorForm';
 import { DataTable } from '../components/DataTable';
 import { Modal } from '../components/Modal';
+import { Button } from '../components/Button';
 
 export default function WorkflowsPage() {
     const queryClient = useQueryClient();
@@ -123,15 +124,8 @@ export default function WorkflowsPage() {
                     onChange={e => setFilter(e.target.value)}
                 />
                 <div className="flex gap-2">
-                    <button
-                        className="px-4 py-1 bg-blue-600 text-white"
-                        onClick={() => setNewModalOpen(true)}
-                    >
-                        New Workflow
-                    </button>
-                    <button className="px-4 py-1 bg-gray-300 dark:bg-neutral-600" onClick={() => refetch()}>
-                        Refresh
-                    </button>
+                    <Button onClick={() => setNewModalOpen(true)}>New Workflow</Button>
+                    <Button variant="secondary" onClick={() => refetch()}>Refresh</Button>
                 </div>
             </div>
             <DataTable
@@ -189,17 +183,13 @@ export default function WorkflowsPage() {
                     )}
                     <WorkflowEditorForm workflow={editing} onChange={setEditing} />
                     <div className="flex justify-end space-x-2">
-                        <button onClick={reset} className="px-4 py-2 rounded bg-gray-300 dark:bg-neutral-600">Reset</button>
-                        <button onClick={cancelEdit} className="px-4 py-2 rounded bg-gray-300 dark:bg-neutral-600">
+                        <Button variant="secondary" onClick={reset}>Reset</Button>
+                        <Button variant="secondary" onClick={cancelEdit} disabled={saveMutation.isPending}>
                             Cancel
-                        </button>
-                        <button
-                            onClick={() => editing && save(editing)}
-                            className="px-4 py-2 rounded bg-blue-600 text-white"
-                            disabled={saveMutation.isPending}
-                        >
+                        </Button>
+                        <Button onClick={() => editing && save(editing)} disabled={saveMutation.isPending}>
                             {saveMutation.isPending ? 'Saving...' : 'Save'}
-                        </button>
+                        </Button>
                     </div>
                 </div>
             )}
@@ -232,15 +222,11 @@ export default function WorkflowsPage() {
                     ))}
                 </select>
                 <div className="flex justify-end gap-2">
-                    <button
-                        className="px-3 py-1 bg-gray-300 dark:bg-neutral-600 rounded"
-                        onClick={() => setNewModalOpen(false)}
-                    >
+                    <Button variant="secondary" onClick={() => setNewModalOpen(false)}>
                         Cancel
-                    </button>
-                    <button
+                    </Button>
+                    <Button
                         disabled={!selectedModel}
-                        className="px-3 py-1 bg-blue-600 text-white rounded disabled:opacity-50"
                         onClick={() => {
                             if (!selectedModel) return;
                             startNewWorkflow(`${selectedModel}.${selectedEvent}`);
@@ -248,7 +234,7 @@ export default function WorkflowsPage() {
                         }}
                     >
                         Create
-                    </button>
+                    </Button>
                 </div>
             </div>
         </Modal>

--- a/AdminUI/src/theme.tsx
+++ b/AdminUI/src/theme.tsx
@@ -1,0 +1,45 @@
+import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+    theme: Theme;
+    toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+    const [theme, setTheme] = useState<Theme>(() => {
+        if (typeof window !== 'undefined') {
+            const stored = localStorage.getItem('theme') as Theme | null;
+            if (stored === 'light' || stored === 'dark') return stored;
+            return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        return 'light';
+    });
+
+    useEffect(() => {
+        const root = document.documentElement;
+        if (theme === 'dark') {
+            root.classList.add('dark');
+        } else {
+            root.classList.remove('dark');
+        }
+        localStorage.setItem('theme', theme);
+    }, [theme]);
+
+    const toggleTheme = () => setTheme(t => (t === 'dark' ? 'light' : 'dark'));
+
+    return (
+        <ThemeContext.Provider value={{ theme, toggleTheme }}>
+            {children}
+        </ThemeContext.Provider>
+    );
+}
+
+export function useTheme() {
+    const ctx = useContext(ThemeContext);
+    if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
+    return ctx;
+}

--- a/AdminUI/tailwind.config.js
+++ b/AdminUI/tailwind.config.js
@@ -12,6 +12,11 @@ export default {
                     DEFAULT: '#6b46ff',
                     dark: '#5536e8',
                 },
+                secondary: {
+                    light: '#e2e8f0',
+                    DEFAULT: '#cbd5e1',
+                    dark: '#94a3b8',
+                },
             },
         },
     },


### PR DESCRIPTION
## Summary
- create `ThemeProvider` and custom hook for dark mode toggling
- add reusable `Button` component
- use new theme and button components across editor pages
- extend Tailwind colors and base styles

## Testing
- `dotnet format TheBackend.sln`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`


------
https://chatgpt.com/codex/tasks/task_e_6886aaf21b4c8324a0c9cbf7aac2dbdd