### PR TITLE
Improve UI theme and tables

### DIFF
--- a/AdminUI/index.html
+++ b/AdminUI/index.html
@@ -4,7 +4,11 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <title>Dynamic Admin UI</title>
   </head>
   <body>
     <div id="root"></div>

--- a/AdminUI/src/components/DataTable.tsx
+++ b/AdminUI/src/components/DataTable.tsx
@@ -15,35 +15,37 @@ interface Props<T> {
 
 export function DataTable<T>({ columns, data, onRowClick }: Props<T>) {
     return (
-        <table className="min-w-full divide-y divide-gray-200 dark:divide-neutral-700">
-            <thead className="bg-gray-50 dark:bg-neutral-800">
-                <tr>
-                    {columns.map((col, idx) => (
-                        <th
-                            key={idx}
-                            className={`px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider ${col.onHeaderClick ? 'cursor-pointer select-none' : ''} ${col.headerClassName ?? ''}`.trim()}
-                            onClick={col.onHeaderClick}
-                        >
-                            {col.header}
-                        </th>
-                    ))}
-                </tr>
-            </thead>
-            <tbody className="bg-white dark:bg-neutral-900 divide-y divide-gray-200 dark:divide-neutral-700">
-                {data.map((row, idx) => (
-                    <tr
-                        key={idx}
-                        onClick={() => onRowClick?.(row)}
-                        className={onRowClick ? 'cursor-pointer hover:bg-gray-100 dark:hover:bg-neutral-800' : ''}
-                    >
-                        {columns.map((col, i) => (
-                            <td key={i} className="px-3 py-2 whitespace-nowrap">
-                                {col.accessor(row)}
-                            </td>
+        <div className="overflow-x-auto rounded border border-gray-200 dark:border-neutral-700 shadow-sm">
+            <table className="min-w-full divide-y divide-gray-200 dark:divide-neutral-700">
+                <thead className="bg-primary text-white dark:bg-primary-dark">
+                    <tr>
+                        {columns.map((col, idx) => (
+                            <th
+                                key={idx}
+                                className={`px-3 py-2 text-left text-xs font-medium uppercase tracking-wider ${col.onHeaderClick ? 'cursor-pointer select-none' : ''} ${col.headerClassName ?? ''}`.trim()}
+                                onClick={col.onHeaderClick}
+                            >
+                                {col.header}
+                            </th>
                         ))}
                     </tr>
-                ))}
-            </tbody>
-        </table>
+                </thead>
+                <tbody className="divide-y divide-gray-200 dark:divide-neutral-700">
+                    {data.map((row, idx) => (
+                        <tr
+                            key={idx}
+                            onClick={() => onRowClick?.(row)}
+                            className={`${idx % 2 === 0 ? 'bg-white dark:bg-neutral-900' : 'bg-gray-50 dark:bg-neutral-800'} ${onRowClick ? 'cursor-pointer hover:bg-gray-100 dark:hover:bg-neutral-700' : ''}`}
+                        >
+                            {columns.map((col, i) => (
+                                <td key={i} className="px-3 py-2 whitespace-nowrap">
+                                    {col.accessor(row)}
+                                </td>
+                            ))}
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
     );
 }

--- a/AdminUI/src/components/RuleEditorForm.tsx
+++ b/AdminUI/src/components/RuleEditorForm.tsx
@@ -69,10 +69,7 @@ export function RuleEditorForm({ workflow, onChange, suggestions }: Props) {
                     <option key={s} value={`entity.${s}`} />
                 ))}
             </datalist>
-            <button
-                onClick={addRule}
-                className="px-2 py-1 rounded bg-gray-300 dark:bg-neutral-700"
-            >
+            <button onClick={addRule} className="btn btn-secondary">
                 Add Rule
             </button>
         </div>

--- a/AdminUI/src/components/WorkflowEditorForm.tsx
+++ b/AdminUI/src/components/WorkflowEditorForm.tsx
@@ -210,7 +210,7 @@ export default function WorkflowEditorForm({ workflow, onChange }: Props) {
                         <button className="text-red-600" onClick={() => removeGlobalVariable(idx)}>Delete</button>
                     </div>
                 ))}
-                <button onClick={addGlobalVariable} className="px-3 py-1 rounded bg-gray-300 dark:bg-neutral-700">
+                <button onClick={addGlobalVariable} className="btn btn-secondary">
                     Add Variable
                 </button>
             </div>
@@ -310,7 +310,7 @@ export default function WorkflowEditorForm({ workflow, onChange }: Props) {
                                             <button className="text-red-600" onClick={() => removeParameter(idx, pIdx)}>Delete</button>
                                         </div>
                                     ))}
-                                    <button onClick={() => addParameter(idx)} className="px-3 py-1 rounded bg-gray-300 dark:bg-neutral-700">
+                                    <button onClick={() => addParameter(idx)} className="btn btn-secondary">
                                         Add Parameter
                                     </button>
                                 </div>
@@ -319,10 +319,10 @@ export default function WorkflowEditorForm({ workflow, onChange }: Props) {
                     </div>
                 ))}
                 <div className="flex gap-2">
-                    <button onClick={addStep} className="px-3 py-1 rounded bg-gray-300 dark:bg-neutral-700">Add Step</button>
+                    <button onClick={addStep} className="btn btn-secondary">Add Step</button>
                     <button
                         onClick={() => navigator.clipboard.writeText(JSON.stringify(workflow, null, 2))}
-                        className="px-3 py-1 rounded bg-gray-300 dark:bg-neutral-700"
+                        className="btn btn-secondary"
                     >
                         Copy JSON
                     </button>

--- a/AdminUI/src/index.css
+++ b/AdminUI/src/index.css
@@ -1,2 +1,21 @@
-@import "tailwindcss";
+@tailwind base;
+@tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    @apply font-sans text-gray-800 dark:text-gray-100 bg-gray-50 dark:bg-neutral-900;
+  }
+}
+
+@layer components {
+  .btn {
+    @apply inline-flex items-center px-3 py-1 rounded-md text-sm font-medium shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50;
+  }
+  .btn-primary {
+    @apply btn bg-primary text-white hover:bg-primary-light disabled:bg-primary-dark;
+  }
+  .btn-secondary {
+    @apply btn bg-gray-300 text-gray-800 hover:bg-gray-400 dark:bg-neutral-700 dark:text-white;
+  }
+}

--- a/AdminUI/src/pages/DataBrowser.tsx
+++ b/AdminUI/src/pages/DataBrowser.tsx
@@ -68,7 +68,7 @@ export default function DataBrowser() {
         <div className="space-y-4">
             <div className="flex items-center justify-between">
                 <h2 className="text-xl font-semibold">{name}</h2>
-                <button className="px-3 py-1 rounded bg-blue-600 text-white" onClick={openCreate}>
+                <button className="btn btn-primary" onClick={openCreate}>
                     New Record
                 </button>
             </div>
@@ -78,7 +78,7 @@ export default function DataBrowser() {
                     <div className="p-4 space-y-4">
                         <h3 className="text-lg font-semibold mb-2">New {name}</h3>
                         <FormFieldBuilder fields={fields} values={formValues} onChange={(n, v) => setFormValues({ ...formValues, [n]: v })} />
-                        <button className="px-3 py-1 rounded bg-blue-600 text-white" onClick={create}>
+                        <button className="btn btn-primary" onClick={create}>
                             Create
                         </button>
                     </div>

--- a/AdminUI/src/pages/ModelEditorPage.tsx
+++ b/AdminUI/src/pages/ModelEditorPage.tsx
@@ -121,7 +121,7 @@ export default function ModelEditorPage() {
                         />
                     </div>
                 ))}
-                <button onClick={addField} className="px-3 py-1 rounded bg-gray-300 dark:bg-neutral-700">
+                <button onClick={addField} className="btn btn-secondary">
                     Add Field
                 </button>
             </div>
@@ -161,11 +161,11 @@ export default function ModelEditorPage() {
                         />
                     </div>
                 ))}
-                <button onClick={addRelationship} className="px-3 py-1 rounded bg-gray-300 dark:bg-neutral-700">
+                <button onClick={addRelationship} className="btn btn-secondary">
                     Add Relationship
                 </button>
             </div>
-            <button onClick={save} className="px-3 py-1 rounded bg-blue-600 text-white">
+            <button onClick={save} className="btn btn-primary">
                 Save
             </button>
         </div>

--- a/AdminUI/src/pages/ModelsPage.tsx
+++ b/AdminUI/src/pages/ModelsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { getModels } from '../services/models';
 import type { ModelDefinition } from '../types/models';
+import { DataTable } from '../components/DataTable';
 
 export default function ModelsPage() {
     const [models, setModels] = useState<ModelDefinition[]>([]);
@@ -29,26 +30,28 @@ export default function ModelsPage() {
         return <div className="text-center text-red-600">{error}</div>;
     }
 
+    const columns = [
+        {
+            header: 'Name',
+            accessor: (row: ModelDefinition) => (
+                <Link className="text-blue-600 hover:underline" to={`/models/${row.modelName}`}>{row.modelName}</Link>
+            ),
+        },
+        {
+            header: 'Fields',
+            accessor: (row: ModelDefinition) => row.properties.length,
+        },
+    ];
+
     return (
         <div className="space-y-4">
             <div className="flex items-center justify-between">
                 <h2 className="text-xl font-semibold">Models</h2>
-                <Link className="px-3 py-1 rounded bg-blue-600 text-white" to="/models/new">
+                <Link className="btn btn-primary" to="/models/new">
                     New Model
                 </Link>
             </div>
-            <ul className="space-y-1">
-                {/* Add a check here just in case, though the above solutions should prevent it */}
-                {Array.isArray(models) && models.length > 0 ? (
-                    models.map(m => (
-                        <li key={m.modelName}>
-                            <Link className="text-blue-600" to={`/models/${m.modelName}`}>{m.modelName}</Link>
-                        </li>
-                    ))
-                ) : (
-                    <li>No models found.</li> // Message if models array is empty
-                )}
-            </ul>
+            <DataTable columns={columns} data={models} />
         </div>
     );
 }

--- a/AdminUI/src/pages/RecordEditor.tsx
+++ b/AdminUI/src/pages/RecordEditor.tsx
@@ -42,7 +42,7 @@ export default function RecordEditor() {
         <div className="space-y-4">
             <h2 className="text-xl font-semibold">{id === 'new' ? 'New' : 'Edit'} {name}</h2>
             <FormFieldBuilder fields={fields} values={values} onChange={(n, v) => setValues({ ...values, [n]: v })} />
-            <button onClick={save} className="px-3 py-1 rounded bg-blue-600 text-white">
+            <button onClick={save} className="btn btn-primary">
                 Save
             </button>
         </div>

--- a/AdminUI/src/pages/RulesPage.tsx
+++ b/AdminUI/src/pages/RulesPage.tsx
@@ -3,6 +3,7 @@ import { getWorkflows, saveWorkflow } from '../services/rules';
 import { getModels } from '../services/models';
 import type { Workflow } from '../types/models';
 import { RuleEditorForm } from '../components/RuleEditorForm';
+import { DataTable } from '../components/DataTable';
 
 export default function RulesPage() {
     const [workflows, setWorkflows] = useState<Workflow[]>([]);
@@ -78,47 +79,44 @@ export default function RulesPage() {
         return <div className="text-center p-4 text-red-600">Error: {error}</div>;
     }
 
+    const columns = [
+        {
+            header: 'Name',
+            accessor: (row: Workflow) => row.workflowName,
+        },
+        {
+            header: 'Rules',
+            accessor: (row: Workflow) => row.rules.length,
+        },
+        {
+            header: 'Actions',
+            accessor: (row: Workflow) => (
+                <button className="text-blue-600 hover:underline" onClick={() => startEdit(row)}>
+                    Edit
+                </button>
+            ),
+        },
+    ];
+
     return (
         <div className="space-y-4 p-4">
             <div className="flex items-center justify-between">
                 <h2 className="text-xl font-semibold">Rules</h2>
-                <button onClick={() => startEdit()} className="px-3 py-1 rounded bg-blue-600 text-white">
+                <button onClick={() => startEdit()} className="btn btn-primary">
                     New
                 </button>
             </div>
-            <ul className="space-y-1">
-                {/* Now, workflows is guaranteed to be an array, so .length and .map are safe */}
-                {workflows.length > 0 ? (
-                    workflows.map(w => (
-                        <li key={w.workflowName} className="flex justify-between items-center py-1">
-                            <span>{w.workflowName}</span>
-                            <button className="text-blue-600 hover:underline" onClick={() => startEdit(w)}>
-                                Edit
-                            </button>
-                        </li>
-                    ))
-                ) : (
-                    <li className="text-gray-500">No rules found.</li>
-                )}
-            </ul>
+            <DataTable columns={columns} data={workflows} />
 
             {editing && (
                 <div className="space-y-2 mt-4 p-4 border rounded shadow-md dark:bg-neutral-700">
                     <h3 className="text-lg font-semibold">{editing.workflowName ? `Editing: ${editing.workflowName}` : 'New Workflow'}</h3>
                     <RuleEditorForm workflow={editing} onChange={setEditing} suggestions={suggestions} />
                     <div className="flex justify-end space-x-2">
-                        <button
-                            onClick={() => setEditing(null)}
-                            className="px-4 py-2 rounded bg-gray-300 text-gray-800 hover:bg-gray-400"
-                            disabled={isSaving}
-                        >
+                        <button onClick={() => setEditing(null)} className="btn btn-secondary" disabled={isSaving}>
                             Cancel
                         </button>
-                        <button
-                            onClick={save}
-                            className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
-                            disabled={isSaving}
-                        >
+                        <button onClick={save} className="btn btn-primary" disabled={isSaving}>
                             {isSaving ? 'Saving...' : 'Save'}
                         </button>
                     </div>

--- a/AdminUI/src/pages/WorkflowsPage.tsx
+++ b/AdminUI/src/pages/WorkflowsPage.tsx
@@ -123,13 +123,10 @@ export default function WorkflowsPage() {
                     onChange={e => setFilter(e.target.value)}
                 />
                 <div className="flex gap-2">
-                    <button
-                        className="px-4 py-1 bg-blue-600 text-white"
-                        onClick={() => setNewModalOpen(true)}
-                    >
+                    <button className="btn btn-primary" onClick={() => setNewModalOpen(true)}>
                         New Workflow
                     </button>
-                    <button className="px-4 py-1 bg-gray-300 dark:bg-neutral-600" onClick={() => refetch()}>
+                    <button className="btn btn-secondary" onClick={() => refetch()}>
                         Refresh
                     </button>
                 </div>
@@ -189,13 +186,11 @@ export default function WorkflowsPage() {
                     )}
                     <WorkflowEditorForm workflow={editing} onChange={setEditing} />
                     <div className="flex justify-end space-x-2">
-                        <button onClick={reset} className="px-4 py-2 rounded bg-gray-300 dark:bg-neutral-600">Reset</button>
-                        <button onClick={cancelEdit} className="px-4 py-2 rounded bg-gray-300 dark:bg-neutral-600">
-                            Cancel
-                        </button>
+                        <button onClick={reset} className="btn btn-secondary">Reset</button>
+                        <button onClick={cancelEdit} className="btn btn-secondary">Cancel</button>
                         <button
                             onClick={() => editing && save(editing)}
-                            className="px-4 py-2 rounded bg-blue-600 text-white"
+                            className="btn btn-primary"
                             disabled={saveMutation.isPending}
                         >
                             {saveMutation.isPending ? 'Saving...' : 'Save'}
@@ -232,15 +227,12 @@ export default function WorkflowsPage() {
                     ))}
                 </select>
                 <div className="flex justify-end gap-2">
-                    <button
-                        className="px-3 py-1 bg-gray-300 dark:bg-neutral-600 rounded"
-                        onClick={() => setNewModalOpen(false)}
-                    >
+                    <button className="btn btn-secondary" onClick={() => setNewModalOpen(false)}>
                         Cancel
                     </button>
                     <button
                         disabled={!selectedModel}
-                        className="px-3 py-1 bg-blue-600 text-white rounded disabled:opacity-50"
+                        className="btn btn-primary disabled:opacity-50"
                         onClick={() => {
                             if (!selectedModel) return;
                             startNewWorkflow(`${selectedModel}.${selectedEvent}`);

--- a/AdminUI/tailwind.config.js
+++ b/AdminUI/tailwind.config.js
@@ -6,6 +6,9 @@ export default {
     content: ['./index.html', './src/**/*.{ts,tsx}'],
     theme: {
         extend: {
+            fontFamily: {
+                sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+            },
             colors: {
                 primary: {
                     light: '#7b61ff',


### PR DESCRIPTION
## Summary
- add Google Font and update page title
- apply global theme styles and reusable button classes
- support custom font in Tailwind config
- redesign `DataTable` with new colors and zebra stripes
- use `DataTable` across Models and Rules pages
- style workflow editor controls with reusable buttons

## Testing
- `dotnet format TheBackend.sln`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`


------
https://chatgpt.com/codex/tasks/task_e_6886ad64479c8324b315239a6e64b431