### PR TITLE
Add themed UI foundation

### DIFF
--- a/AdminUI/README.md
+++ b/AdminUI/README.md
@@ -2,6 +2,12 @@
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
+## Custom Theme
+
+This project includes a Tailwind configuration inspired by Strapi and Directus.
+Light and dark modes are controlled via `ThemeContext`, and key colors are
+defined in `tailwind.config.js` under `primary` and `neutral` palettes.
+
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh

--- a/AdminUI/package-lock.json
+++ b/AdminUI/package-lock.json
@@ -27,6 +27,7 @@
       "devDependencies": {
         "@eslint/js": "^9.31.0",
         "@tailwindcss/postcss": "^4.1.11",
+        "@tailwindcss/typography": "^0.5.9",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
@@ -2197,6 +2198,22 @@
         "tailwindcss": "4.1.11"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.16.tgz",
+      "integrity": "sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
     "node_modules/@tailwindcss/vite": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.11.tgz",
@@ -3215,6 +3232,19 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/csstype": {
@@ -4467,6 +4497,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -4803,6 +4847,20 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/postcss-value-parser": {
@@ -5387,6 +5445,13 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.0.5",

--- a/AdminUI/package.json
+++ b/AdminUI/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@eslint/js": "^9.31.0",
     "@tailwindcss/postcss": "^4.1.11",
+    "@tailwindcss/typography": "^0.5.9",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",

--- a/AdminUI/src/components/Header.tsx
+++ b/AdminUI/src/components/Header.tsx
@@ -1,26 +1,19 @@
-import { useState } from 'react';
+import { useContext } from 'react';
+import { ThemeContext } from '../contexts/ThemeContext';
 
 export function Header() {
-    const [dark, setDark] = useState(
-        window.matchMedia('(prefers-color-scheme: dark)').matches
-    );
-
-    const toggle = () => {
-        const root = document.documentElement;
-        if (dark) {
-            root.classList.remove('dark');
-        } else {
-            root.classList.add('dark');
-        }
-        setDark(!dark);
-    };
+    const { isDark, toggle } = useContext(ThemeContext);
 
     return (
         <header className="h-12 flex items-center justify-between px-4 border-b border-gray-200 dark:border-neutral-700">
             <h1 className="text-lg font-semibold">AdminUI</h1>
             <div className="flex items-center gap-3">
-                <button onClick={toggle} className="px-2 py-1 rounded bg-gray-200 dark:bg-neutral-700">
-                    {dark ? 'Light' : 'Dark'}
+                <button
+                    onClick={toggle}
+                    className="px-2 py-1 rounded bg-neutral-200 dark:bg-neutral-700"
+                    aria-label="Toggle color scheme"
+                >
+                    {isDark ? 'Light' : 'Dark'}
                 </button>
                 <div className="w-8 h-8 rounded-full bg-gray-400" />
             </div>

--- a/AdminUI/src/components/Sidebar.tsx
+++ b/AdminUI/src/components/Sidebar.tsx
@@ -2,13 +2,13 @@ import { NavLink } from 'react-router-dom';
 
 export function Sidebar() {
     return (
-        <aside className="w-16 md:w-48 bg-gray-200 dark:bg-neutral-800 h-full flex flex-col">
+        <aside className="w-16 md:w-48 bg-neutral-100 dark:bg-neutral-800 h-full flex flex-col">
             <nav className="flex-1 p-2 space-y-2">
-                <NavLink className="block p-2 rounded hover:bg-gray-300 dark:hover:bg-neutral-700" to="/">Dashboard</NavLink>
-                <NavLink className="block p-2 rounded hover:bg-gray-300 dark:hover:bg-neutral-700" to="/models">Models</NavLink>
-                <NavLink className="block p-2 rounded hover:bg-gray-300 dark:hover:bg-neutral-700" to="/rules">Rules</NavLink>
-                <NavLink className="block p-2 rounded hover:bg-gray-300 dark:hover:bg-neutral-700" to="/workflows">Workflows</NavLink>
-                <NavLink className="block p-2 rounded hover:bg-gray-300 dark:hover:bg-neutral-700" to="/workflow-dashboard">Workflow Studio</NavLink>
+                <NavLink className="block p-2 rounded hover:bg-neutral-200 dark:hover:bg-neutral-700" to="/">Dashboard</NavLink>
+                <NavLink className="block p-2 rounded hover:bg-neutral-200 dark:hover:bg-neutral-700" to="/models">Models</NavLink>
+                <NavLink className="block p-2 rounded hover:bg-neutral-200 dark:hover:bg-neutral-700" to="/rules">Rules</NavLink>
+                <NavLink className="block p-2 rounded hover:bg-neutral-200 dark:hover:bg-neutral-700" to="/workflows">Workflows</NavLink>
+                <NavLink className="block p-2 rounded hover:bg-neutral-200 dark:hover:bg-neutral-700" to="/workflow-dashboard">Workflow Studio</NavLink>
             </nav>
         </aside>
     );

--- a/AdminUI/src/contexts/ThemeContext.tsx
+++ b/AdminUI/src/contexts/ThemeContext.tsx
@@ -1,0 +1,38 @@
+import { createContext, useEffect, useState } from 'react';
+
+interface ThemeContextValue {
+    isDark: boolean;
+    toggle: () => void;
+}
+
+export const ThemeContext = createContext<ThemeContextValue>({
+    isDark: false,
+    toggle: () => {},
+});
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+    const [isDark, setIsDark] = useState<boolean>(() => {
+        const stored = localStorage.getItem('isDark');
+        if (stored !== null) {
+            return stored === 'true';
+        }
+        return window.matchMedia('(prefers-color-scheme: dark)').matches;
+    });
+
+    useEffect(() => {
+        if (isDark) {
+            document.documentElement.classList.add('dark');
+        } else {
+            document.documentElement.classList.remove('dark');
+        }
+        localStorage.setItem('isDark', String(isDark));
+    }, [isDark]);
+
+    const toggle = () => setIsDark((prev) => !prev);
+
+    return (
+        <ThemeContext.Provider value={{ isDark, toggle }}>
+            {children}
+        </ThemeContext.Provider>
+    );
+}

--- a/AdminUI/src/index.css
+++ b/AdminUI/src/index.css
@@ -4,7 +4,7 @@
 
 @layer base {
   body {
-    @apply font-sans text-gray-800 dark:text-gray-100 bg-gray-50 dark:bg-neutral-900;
+    @apply font-sans text-neutral-900 dark:text-neutral-50 bg-neutral-50 dark:bg-neutral-900;
   }
 }
 
@@ -13,9 +13,9 @@
     @apply inline-flex items-center px-3 py-1 rounded-md text-sm font-medium shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50;
   }
   .btn-primary {
-    @apply btn bg-primary text-white hover:bg-primary-light disabled:bg-primary-dark;
+    @apply btn bg-primary-600 text-white hover:bg-primary-700 disabled:bg-primary-500;
   }
   .btn-secondary {
-    @apply btn bg-gray-300 text-gray-800 hover:bg-gray-400 dark:bg-neutral-700 dark:text-white;
+    @apply btn bg-neutral-200 text-neutral-700 hover:bg-neutral-300 dark:bg-neutral-700 dark:text-white;
   }
 }

--- a/AdminUI/src/layout/Layout.tsx
+++ b/AdminUI/src/layout/Layout.tsx
@@ -8,11 +8,11 @@ interface Props {
 
 export function Layout({ children }: Props) {
     return (
-        <div className="flex h-screen bg-gray-100 dark:bg-neutral-900">
+        <div className="flex h-screen bg-neutral-50 dark:bg-neutral-900">
             <Sidebar />
             <div className="flex flex-col flex-1">
                 <Header />
-                <main className="flex-1 overflow-auto p-4">{children}</main>
+                <main className="flex-1 overflow-auto p-4 animate-fadeIn">{children}</main>
             </div>
         </div>
     );

--- a/AdminUI/src/main.tsx
+++ b/AdminUI/src/main.tsx
@@ -3,13 +3,16 @@ import { createRoot } from 'react-dom/client';
 import App from './App';
 import './index.css';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from './contexts/ThemeContext';
 
 const queryClient = new QueryClient();
 
 createRoot(document.getElementById('root')!).render(
     <StrictMode>
-        <QueryClientProvider client={queryClient}>
-            <App />
-        </QueryClientProvider>
+        <ThemeProvider>
+            <QueryClientProvider client={queryClient}>
+                <App />
+            </QueryClientProvider>
+        </ThemeProvider>
     </StrictMode>
 );

--- a/AdminUI/tailwind.config.js
+++ b/AdminUI/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 import forms from '@tailwindcss/forms';
+import typography from '@tailwindcss/typography';
 
 export default {
     darkMode: 'class',
@@ -11,12 +12,34 @@ export default {
             },
             colors: {
                 primary: {
-                    light: '#7b61ff',
-                    DEFAULT: '#6b46ff',
-                    dark: '#5536e8',
+                    100: '#f6ecfc',
+                    200: '#e0c1f4',
+                    500: '#ac73e6',
+                    600: '#9736e8',
+                    700: '#8312d1',
+                },
+                neutral: {
+                    50: '#f9fafb',
+                    100: '#f3f4f6',
+                    200: '#e5e7eb',
+                    500: '#6b7280',
+                    700: '#374151',
+                    900: '#111827',
+                },
+                success: '#22c55e',
+                warning: '#eab308',
+                error: '#ef4444',
+            },
+            animation: {
+                fadeIn: 'fadeIn 0.3s ease-in-out',
+            },
+            keyframes: {
+                fadeIn: {
+                    '0%': { opacity: '0' },
+                    '100%': { opacity: '1' },
                 },
             },
         },
     },
-    plugins: [forms],
+    plugins: [forms, typography],
 };


### PR DESCRIPTION
## Summary
- add Strapi/Directus inspired palette in `tailwind.config.js`
- introduce `ThemeContext` with dark mode persistence
- hook `ThemeProvider` into app root
- update header and layout with context usage and animations
- tweak global styles and sidebar colors
- document the theme in README

## Testing
- `dotnet format TheBackend.sln --verbosity minimal`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`

------
https://chatgpt.com/codex/tasks/task_e_6886be1c9aa48324bb9cb4cacb48d2d6