### PR TITLE
Improve AdminUI theme and usability

### DIFF
--- a/AdminUI/src/components/DataTable.tsx
+++ b/AdminUI/src/components/DataTable.tsx
@@ -46,6 +46,7 @@ const Tr = styled.tr<{ interactive: boolean; even: boolean }>`
     ${({ interactive, theme }) =>
         interactive &&
         `cursor: pointer;
+        transition: background ${theme.transitions.fast};
         &:hover { background: ${theme.colors.accent}30; }`}
 `;
 

--- a/AdminUI/src/components/Drawer.tsx
+++ b/AdminUI/src/components/Drawer.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import styled from 'styled-components';
 
 interface Props {
     open: boolean;
@@ -6,12 +7,25 @@ interface Props {
     children: ReactNode;
 }
 
+const Panel = styled.div<{ open: boolean }>`
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    width: 16rem;
+    background: ${({ theme }) => theme.colors.background};
+    color: ${({ theme }) => theme.colors.text};
+    transform: ${({ open }) => (open ? 'translateX(0)' : 'translateX(100%)')};
+    transition: transform ${({ theme }) => theme.transitions.normal};
+    box-shadow: ${({ theme }) => theme.shadows.lg};
+    overflow-y: auto;
+`;
+
 export function Drawer({ open, onClose, children }: Props) {
     return (
-        <div className={`fixed inset-y-0 right-0 w-64 bg-white dark:bg-neutral-800 transform transition-transform ${open ? 'translate-x-0' : 'translate-x-full'}`}
-            onClick={e => e.stopPropagation()}>
-            <button className="p-2" onClick={onClose}>Close</button>
+        <Panel open={open} onClick={e => e.stopPropagation()}>
+            <button style={{ float: 'right' }} onClick={onClose}>Close</button>
             {children}
-        </div>
+        </Panel>
     );
 }

--- a/AdminUI/src/components/Header.tsx
+++ b/AdminUI/src/components/Header.tsx
@@ -2,13 +2,36 @@ import styled from 'styled-components';
 import { useTheme } from '../ThemeContext';
 import { Button } from './common/Button';
 
+interface Props {
+    onMenuClick: () => void;
+}
+
 const HeaderWrapper = styled.header`
+    position: sticky;
+    top: 0;
+    z-index: 10;
     height: 3rem;
     display: flex;
     align-items: center;
     justify-content: space-between;
     padding: 0 ${({ theme }) => theme.spacing.md};
     border-bottom: 1px solid ${({ theme }) => theme.colors.primaryLight};
+    background: ${({ theme }) => theme.colors.background};
+    box-shadow: ${({ theme }) => theme.shadows.sm};
+`;
+
+const MenuButton = styled.button`
+    display: none;
+    background: none;
+    border: none;
+    font-size: ${({ theme }) => theme.fontSizes.lg};
+    @media (max-width: 768px) {
+        display: inline-block;
+    }
+    &:focus-visible {
+        outline: 2px solid ${({ theme }) => theme.colors.primaryLight};
+        outline-offset: 2px;
+    }
 `;
 
 
@@ -25,11 +48,12 @@ const Right = styled.div`
     gap: ${({ theme }) => theme.spacing.sm};
 `;
 
-export function Header() {
+export function Header({ onMenuClick }: Props) {
     const { dark, toggle } = useTheme();
 
     return (
         <HeaderWrapper>
+            <MenuButton aria-label="Open menu" onClick={onMenuClick}>☰</MenuButton>
             <h1>AdminUI</h1>
             <Right>
                 <Button variant="secondary" onClick={toggle} aria-label="Toggle dark mode">

--- a/AdminUI/src/components/Modal.tsx
+++ b/AdminUI/src/components/Modal.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import styled from 'styled-components';
 
 interface Props {
     open: boolean;
@@ -6,13 +7,28 @@ interface Props {
     children: ReactNode;
 }
 
+const Overlay = styled.div`
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+`;
+
+const Panel = styled.div`
+    background: ${({ theme }) => theme.colors.background};
+    color: ${({ theme }) => theme.colors.text};
+    padding: ${({ theme }) => theme.spacing.md};
+    border-radius: ${({ theme }) => theme.radius};
+    box-shadow: ${({ theme }) => theme.shadows.md};
+`;
+
 export function Modal({ open, onClose, children }: Props) {
     if (!open) return null;
     return (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center" onClick={onClose}>
-            <div className="bg-white dark:bg-neutral-800 p-4 rounded" onClick={e => e.stopPropagation()}>
-                {children}
-            </div>
-        </div>
+        <Overlay onClick={onClose}>
+            <Panel onClick={e => e.stopPropagation()}>{children}</Panel>
+        </Overlay>
     );
 }

--- a/AdminUI/src/components/Sidebar.tsx
+++ b/AdminUI/src/components/Sidebar.tsx
@@ -1,12 +1,34 @@
 import { NavLink } from 'react-router-dom';
 import styled from 'styled-components';
 
-const Aside = styled.aside`
+interface Props {
+    open: boolean;
+    onClose?: () => void;
+}
+const Wrapper = styled.div<{ open: boolean }>`
+    @media (max-width: 768px) {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.4);
+        display: ${({ open }) => (open ? 'block' : 'none')};
+    }
+`;
+
+const Aside = styled.aside<{ open: boolean }>`
     width: 12rem;
     background: ${({ theme }) => theme.colors.primaryLight}10;
     height: 100%;
     display: flex;
     flex-direction: column;
+    @media (max-width: 768px) {
+        position: fixed;
+        left: 0;
+        top: 0;
+        transform: ${({ open }) => (open ? 'translateX(0)' : 'translateX(-100%)')};
+        transition: transform ${({ theme }) => theme.transitions.normal};
+        box-shadow: ${({ theme }) => theme.shadows.lg};
+        z-index: 20;
+    }
 `;
 
 const Nav = styled.nav`
@@ -22,6 +44,7 @@ const LinkItem = styled(NavLink)`
     border-radius: 4px;
     text-decoration: none;
     color: inherit;
+    transition: background ${({ theme }) => theme.transitions.fast};
 
     &:hover {
         background: ${({ theme }) => theme.colors.primaryLight};
@@ -34,16 +57,18 @@ const LinkItem = styled(NavLink)`
     }
 `;
 
-export function Sidebar() {
+export function Sidebar({ open, onClose }: Props) {
     return (
-        <Aside>
-            <Nav>
-                <LinkItem to="/">Dashboard</LinkItem>
-                <LinkItem to="/models">Models</LinkItem>
-                <LinkItem to="/rules">Rules</LinkItem>
-                <LinkItem to="/workflows">Workflows</LinkItem>
-                <LinkItem to="/workflow-dashboard">Workflow Studio</LinkItem>
-            </Nav>
-        </Aside>
+        <Wrapper open={open} onClick={onClose}>
+            <Aside open={open} onClick={e => e.stopPropagation()}>
+                <Nav>
+                    <LinkItem to="/" onClick={onClose}>Dashboard</LinkItem>
+                    <LinkItem to="/models" onClick={onClose}>Models</LinkItem>
+                    <LinkItem to="/rules" onClick={onClose}>Rules</LinkItem>
+                    <LinkItem to="/workflows" onClick={onClose}>Workflows</LinkItem>
+                    <LinkItem to="/workflow-dashboard" onClick={onClose}>Workflow Studio</LinkItem>
+                </Nav>
+            </Aside>
+        </Wrapper>
     );
 }

--- a/AdminUI/src/components/common/Button.tsx
+++ b/AdminUI/src/components/common/Button.tsx
@@ -24,9 +24,13 @@ const StyledButton = styled.button<{ variant: ButtonVariant }>`
                 return theme.colors.primary;
         }
     }};
-    transition: background 0.2s;
+    transition: background ${({ theme }) => theme.transitions.fast};
     &:hover {
         opacity: 0.9;
+    }
+    &:focus-visible {
+        outline: 2px solid ${({ theme }) => theme.colors.primaryLight};
+        outline-offset: 2px;
     }
     &:disabled {
         opacity: 0.5;

--- a/AdminUI/src/components/common/Input.tsx
+++ b/AdminUI/src/components/common/Input.tsx
@@ -10,7 +10,8 @@ const StyledInput = styled.input`
     background: ${({ theme }) => theme.colors.background};
     color: ${({ theme }) => theme.colors.text};
     font-size: ${({ theme }) => theme.fontSizes.md};
-    &:focus {
+    transition: border-color ${({ theme }) => theme.transitions.fast};
+    &:focus-visible {
         outline: 2px solid ${({ theme }) => theme.colors.primaryLight};
         outline-offset: 2px;
     }

--- a/AdminUI/src/components/common/Skeleton.tsx
+++ b/AdminUI/src/components/common/Skeleton.tsx
@@ -1,0 +1,20 @@
+import styled, { keyframes } from 'styled-components';
+
+const shimmer = keyframes`
+  0% { background-position: -200px 0; }
+  100% { background-position: calc(200px + 100%) 0; }
+`;
+
+const StyledSkeleton = styled.div<{height?:string}>`
+  background: #e1e1e1;
+  background-image: linear-gradient(90deg, #e1e1e1 0px, #f2f2f2 40px, #e1e1e1 80px);
+  background-size: 200px 100%;
+  background-repeat: no-repeat;
+  border-radius: ${({ theme }) => theme.radius};
+  height: ${({height}) => height ?? '1rem'};
+  animation: ${shimmer} 1.2s infinite linear;
+`;
+
+export default function Skeleton({ height }: { height?: string }) {
+  return <StyledSkeleton height={height} />;
+}

--- a/AdminUI/src/layout/Layout.tsx
+++ b/AdminUI/src/layout/Layout.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { useState } from 'react';
 import { Sidebar } from '../components/Sidebar';
 import { Header } from '../components/Header';
 import styled from 'styled-components';
@@ -23,6 +24,8 @@ const Main = styled.main`
     flex: 1;
     overflow: auto;
     padding: ${({ theme }) => theme.spacing.md};
+    max-width: ${({ theme }) => theme.maxWidth};
+    margin: 0 auto;
 `;
 
 const Footer = styled.footer`
@@ -32,11 +35,13 @@ const Footer = styled.footer`
 `;
 
 export function Layout({ children }: Props) {
+    const [sidebarOpen, setSidebarOpen] = useState(false);
+
     return (
         <Wrapper>
-            <Sidebar />
+            <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
             <Content>
-                <Header />
+                <Header onMenuClick={() => setSidebarOpen(true)} />
                 <Main>{children}</Main>
                 <Footer>DynamicApi © 2025</Footer>
             </Content>

--- a/AdminUI/src/pages/ModelsPage.tsx
+++ b/AdminUI/src/pages/ModelsPage.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { getModels } from '../services/models';
 import type { ModelDefinition } from '../types/models';
 import { DataTable } from '../components/DataTable';
+import Skeleton from '../components/common/Skeleton';
 
 export default function ModelsPage() {
     const [models, setModels] = useState<ModelDefinition[]>([]);
@@ -23,7 +24,13 @@ export default function ModelsPage() {
     }, []);
 
     if (isLoading) {
-        return <div className="text-center">Loading models...</div>;
+        return (
+            <div className="space-y-2">
+                <Skeleton height="2rem" />
+                <Skeleton height="2rem" />
+                <Skeleton height="2rem" />
+            </div>
+        );
     }
 
     if (error) {

--- a/AdminUI/src/styled.d.ts
+++ b/AdminUI/src/styled.d.ts
@@ -10,6 +10,8 @@ declare module 'styled-components' {
       accent: string;
       secondary: string;
       border: string;
+      success: string;
+      warning: string;
     };
     spacing: {
       sm: string;
@@ -18,6 +20,16 @@ declare module 'styled-components' {
       xl: string;
     };
     radius: string;
+    shadows: {
+      sm: string;
+      md: string;
+      lg: string;
+    };
+    transitions: {
+      fast: string;
+      normal: string;
+    };
+    maxWidth: string;
     fontSizes: {
       sm: string;
       md: string;

--- a/AdminUI/src/theme.ts
+++ b/AdminUI/src/theme.ts
@@ -1,4 +1,4 @@
-import { DefaultTheme, createGlobalStyle } from 'styled-components';
+import { DefaultTheme, createGlobalStyle, keyframes } from 'styled-components';
 
 export const lightTheme: DefaultTheme = {
     colors: {
@@ -9,6 +9,8 @@ export const lightTheme: DefaultTheme = {
         accent: '#ff6b6b',
         secondary: '#4f46e5',
         border: '#d1d5db',
+        success: '#16a34a',
+        warning: '#f59e0b',
     },
     spacing: {
         sm: '0.5rem',
@@ -17,6 +19,16 @@ export const lightTheme: DefaultTheme = {
         xl: '4rem',
     },
     radius: '4px',
+    shadows: {
+        sm: '0 1px 2px rgba(0,0,0,0.05)',
+        md: '0 4px 6px rgba(0,0,0,0.1)',
+        lg: '0 10px 15px rgba(0,0,0,0.15)',
+    },
+    transitions: {
+        fast: '0.2s',
+        normal: '0.3s',
+    },
+    maxWidth: '1200px',
     fontSizes: {
         sm: '0.875rem',
         md: '1rem',
@@ -37,6 +49,8 @@ export const darkTheme: DefaultTheme = {
         accent: '#ff8787',
         secondary: '#6366f1',
         border: '#374151',
+        success: '#16a34a',
+        warning: '#f59e0b',
     },
     spacing: {
         sm: '0.5rem',
@@ -45,6 +59,16 @@ export const darkTheme: DefaultTheme = {
         xl: '4rem',
     },
     radius: '4px',
+    shadows: {
+        sm: '0 1px 2px rgba(0,0,0,0.4)',
+        md: '0 4px 6px rgba(0,0,0,0.5)',
+        lg: '0 10px 15px rgba(0,0,0,0.6)',
+    },
+    transitions: {
+        fast: '0.2s',
+        normal: '0.3s',
+    },
+    maxWidth: '1200px',
     fontSizes: {
         sm: '0.875rem',
         md: '1rem',
@@ -57,8 +81,14 @@ export const darkTheme: DefaultTheme = {
 };
 
 export const GlobalStyle = createGlobalStyle`
-  body {
+  *, *::before, *::after {
+    box-sizing: border-box;
+  }
+  html, body {
     margin: 0;
+    padding: 0;
+  }
+  body {
     font-family: ${({ theme }) => theme.fonts.body};
     background: ${({ theme }) => theme.colors.background};
     color: ${({ theme }) => theme.colors.text};
@@ -70,6 +100,10 @@ export const GlobalStyle = createGlobalStyle`
     &:hover {
       text-decoration: underline;
     }
+    &:focus-visible {
+      outline: 2px solid ${({ theme }) => theme.colors.primaryLight};
+      outline-offset: 2px;
+    }
   }
 
   input,
@@ -77,5 +111,9 @@ export const GlobalStyle = createGlobalStyle`
   select,
   textarea {
     font-family: ${({ theme }) => theme.fonts.body};
+    &:focus-visible {
+      outline: 2px solid ${({ theme }) => theme.colors.primaryLight};
+      outline-offset: 2px;
+    }
   }
 `;


### PR DESCRIPTION
## Summary
- extend theme with status colors, shadows and transitions
- add global reset and focus styles
- implement responsive sidebar and sticky header
- style modal/drawer with shadows
- add skeleton loader for models page
- tweak components to use new theme tokens

## Testing
- `dotnet format TheBackend.sln`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`


------
https://chatgpt.com/codex/tasks/task_e_6887f4b7a0fc8324878606a2db7e1615