### PR TITLE
Fix DataTable responsive CSS

### DIFF
--- a/AdminUI/src/components/DataTable.tsx
+++ b/AdminUI/src/components/DataTable.tsx
@@ -14,11 +14,6 @@ interface Props<T> {
     onRowClick?: (row: T) => void;
 }
 
-const Wrapper = styled.div`
-    overflow-x: auto;
-    border: 1px solid ${({ theme }) => theme.colors.primaryLight};
-    border-radius: 4px;
-`;
 
 const Table = styled.table`
     width: 100%;
@@ -60,19 +55,26 @@ const Td = styled.td`
     word-break: break-word;
 `;
 
-@media (max-width: 640px) {
-    ${Th}, ${Td} {
-        display: block;
-        width: 100%;
+const Wrapper = styled.div`
+    overflow-x: auto;
+    border: 1px solid ${({ theme }) => theme.colors.primaryLight};
+    border-radius: 4px;
+
+    @media (max-width: 640px) {
+        ${Th}, ${Td} {
+            display: block;
+            width: 100%;
+        }
+        ${Tr} {
+            display: block;
+            margin-bottom: ${({ theme }) => theme.spacing.sm};
+        }
+        ${Table} {
+            min-width: 100%;
+        }
     }
-    ${Tr} {
-        display: block;
-        margin-bottom: ${({ theme }) => theme.spacing.sm};
-    }
-    ${Table} {
-        min-width: 100%;
-    }
-}
+`;
+
 
 export function DataTable<T>({ columns, data, onRowClick }: Props<T>) {
     return (


### PR DESCRIPTION
## Summary
- fix Babel build issue by moving `@media` block inside a styled component

## Testing
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`


------
https://chatgpt.com/codex/tasks/task_e_6887fad4e3c083249cd0e9e2e7e115c3