### PR TITLE
Improve AdminUI accessibility

### DIFF
--- a/AdminUI/src/components/DataTable.tsx
+++ b/AdminUI/src/components/DataTable.tsx
@@ -6,6 +6,7 @@ interface Column<T> {
     accessor: (row: T) => ReactNode;
     onHeaderClick?: () => void;
     headerClassName?: string;
+    ariaSort?: 'none' | 'ascending' | 'descending';
 }
 
 interface Props<T> {
@@ -87,6 +88,7 @@ export function DataTable<T>({ columns, data, onRowClick }: Props<T>) {
                                 clickable={!!col.onHeaderClick}
                                 key={idx}
                                 onClick={col.onHeaderClick}
+                                aria-sort={col.ariaSort}
                             >
                                 {col.header}
                             </Th>
@@ -94,18 +96,31 @@ export function DataTable<T>({ columns, data, onRowClick }: Props<T>) {
                     </tr>
                 </Thead>
                 <Tbody>
-                    {data.map((row, idx) => (
-                        <Tr
-                            key={idx}
-                            even={idx % 2 === 0}
-                            interactive={!!onRowClick}
-                            onClick={() => onRowClick?.(row)}
-                        >
-                            {columns.map((col, i) => (
-                                <Td key={i}>{col.accessor(row)}</Td>
-                            ))}
+                    {data.length === 0 ? (
+                        <Tr interactive={false} even={false}>
+                            <Td colSpan={columns.length}>No data available</Td>
                         </Tr>
-                    ))}
+                    ) : (
+                        data.map((row, idx) => (
+                            <Tr
+                                key={idx}
+                                even={idx % 2 === 0}
+                                interactive={!!onRowClick}
+                                onClick={() => onRowClick?.(row)}
+                                tabIndex={onRowClick ? 0 : -1}
+                                onKeyDown={e => {
+                                    if ((e.key === 'Enter' || e.key === ' ') && onRowClick) {
+                                        e.preventDefault();
+                                        onRowClick(row);
+                                    }
+                                }}
+                            >
+                                {columns.map((col, i) => (
+                                    <Td key={i}>{col.accessor(row)}</Td>
+                                ))}
+                            </Tr>
+                        ))
+                    )}
                 </Tbody>
             </Table>
         </Wrapper>

--- a/AdminUI/src/components/Drawer.tsx
+++ b/AdminUI/src/components/Drawer.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { useEffect } from 'react';
 import styled from 'styled-components';
 
 interface Props {
@@ -6,6 +7,14 @@ interface Props {
     onClose: () => void;
     children: ReactNode;
 }
+
+const Overlay = styled.div<{ open: boolean }>`
+    display: ${({ open }) => (open ? 'block' : 'none')};
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 20;
+`;
 
 const Panel = styled.div<{ open: boolean }>`
     position: fixed;
@@ -25,12 +34,23 @@ const Panel = styled.div<{ open: boolean }>`
 `;
 
 export function Drawer({ open, onClose, children }: Props) {
+    useEffect(() => {
+        if (!open) return;
+        const handler = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') onClose();
+        };
+        window.addEventListener('keydown', handler);
+        return () => window.removeEventListener('keydown', handler);
+    }, [open, onClose]);
+
     return (
-        <Panel open={open} onClick={e => e.stopPropagation()}>
-            <button aria-label="Close" style={{ float: 'right' }} onClick={onClose}>
-                &times;
-            </button>
-            {children}
-        </Panel>
+        <Overlay open={open} onClick={onClose} aria-label="Close drawer">
+            <Panel open={open} onClick={e => e.stopPropagation()}>
+                <button aria-label="Close" style={{ float: 'right' }} onClick={onClose}>
+                    &times;
+                </button>
+                {children}
+            </Panel>
+        </Overlay>
     );
 }

--- a/AdminUI/src/components/Header.tsx
+++ b/AdminUI/src/components/Header.tsx
@@ -59,7 +59,7 @@ export function Header({ onMenuClick }: Props) {
                 <Button variant="secondary" onClick={toggle} aria-label="Toggle dark mode">
                     {dark ? 'Light' : 'Dark'}
                 </Button>
-                <Avatar />
+                <Avatar role="img" aria-label="User avatar" />
             </Right>
         </HeaderWrapper>
     );

--- a/AdminUI/src/components/Modal.tsx
+++ b/AdminUI/src/components/Modal.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import styled from 'styled-components';
 
 interface Props {
@@ -26,17 +26,22 @@ const Panel = styled.div`
 `;
 
 export function Modal({ open, onClose, children }: Props) {
+    const panelRef = useRef<HTMLDivElement>(null);
     if (!open) return null;
     useEffect(() => {
         const handler = (e: KeyboardEvent) => {
             if (e.key === 'Escape') onClose();
         };
         window.addEventListener('keydown', handler);
+        const first = panelRef.current?.querySelector<HTMLElement>(
+            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        );
+        first?.focus();
         return () => window.removeEventListener('keydown', handler);
     }, [onClose]);
     return (
         <Overlay onClick={onClose}>
-            <Panel onClick={e => e.stopPropagation()}>
+            <Panel ref={panelRef} onClick={e => e.stopPropagation()}>
                 <button
                     aria-label="Close"
                     onClick={onClose}

--- a/AdminUI/src/components/Toast.tsx
+++ b/AdminUI/src/components/Toast.tsx
@@ -14,7 +14,11 @@ export default function Toast({ message, onClose }: Props) {
 
     if (!message) return null;
     return (
-        <div className="fixed bottom-4 right-4 bg-black text-white px-4 py-2 rounded shadow">
+        <div
+            role="status"
+            aria-live="polite"
+            className="fixed bottom-4 right-4 bg-black text-white px-4 py-2 rounded shadow"
+        >
             {message}
         </div>
     );

--- a/AdminUI/src/layout/Layout.tsx
+++ b/AdminUI/src/layout/Layout.tsx
@@ -14,6 +14,19 @@ const Wrapper = styled.div`
     background: ${({ theme }) => theme.colors.background};
 `;
 
+const SkipLink = styled.a`
+    position: absolute;
+    left: -999px;
+    top: 0;
+    padding: ${({ theme }) => theme.spacing.sm};
+    background: ${({ theme }) => theme.colors.accent};
+    color: #fff;
+    z-index: 100;
+    &:focus {
+        left: 0;
+    }
+`;
+
 const Content = styled.div`
     display: flex;
     flex-direction: column;
@@ -39,10 +52,11 @@ export function Layout({ children }: Props) {
 
     return (
         <Wrapper>
+            <SkipLink href="#main-content">Skip to content</SkipLink>
             <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
             <Content>
                 <Header onMenuClick={() => setSidebarOpen(true)} />
-                <Main>{children}</Main>
+                <Main id="main-content">{children}</Main>
                 <Footer>DynamicApi © 2025</Footer>
             </Content>
         </Wrapper>

--- a/AdminUI/src/pages/DataBrowser.tsx
+++ b/AdminUI/src/pages/DataBrowser.tsx
@@ -7,11 +7,13 @@ import { DataTable } from '../components/DataTable';
 import { Drawer } from '../components/Drawer';
 import { FormFieldBuilder } from '../components/FormFieldBuilder';
 import { Button } from '../components/common/Button';
+import Skeleton from '../components/common/Skeleton';
 
 export default function DataBrowser() {
     const { name } = useParams();
     const [model, setModel] = useState<ModelDefinition | null>(null);
     const [records, setRecords] = useState<Record<string, unknown>[]>([]);
+    const [loading, setLoading] = useState(true);
     const [selected, setSelected] = useState<Record<string, unknown> | null>(null);
     const [drawerOpen, setDrawerOpen] = useState(false);
     const [isCreating, setIsCreating] = useState(false);
@@ -19,12 +21,14 @@ export default function DataBrowser() {
 
     useEffect(() => {
         if (!name) return;
+        setLoading(true);
         getModels()
             .then(list => setModel(list.find(m => m.modelName === name) || null))
             .catch(console.error);
         getRecords(name)
             .then(setRecords)
-            .catch(console.error);
+            .catch(console.error)
+            .finally(() => setLoading(false));
     }, [name]);
 
     const remove = async (id: unknown) => {
@@ -47,7 +51,15 @@ export default function DataBrowser() {
         setDrawerOpen(false);
     };
 
-    if (!model) return <div>Loading...</div>;
+    if (loading || !model) {
+        return (
+            <div className="space-y-2">
+                <Skeleton height="2rem" />
+                <Skeleton height="2rem" />
+                <Skeleton height="2rem" />
+            </div>
+        );
+    }
 
     const columns = model.properties.map(p => ({
         header: p.name,
@@ -79,7 +91,7 @@ export default function DataBrowser() {
         <div className="space-y-4">
             <div className="flex items-center justify-between">
                 <h2 className="text-xl font-semibold">{name}</h2>
-                <Button onClick={openCreate}>New Record</Button>
+                <Button onClick={openCreate} aria-label="Create new record">New Record</Button>
             </div>
             <DataTable columns={columns} data={records} onRowClick={r => { setSelected(r); setIsCreating(false); setDrawerOpen(true); }} />
             <Drawer open={drawerOpen} onClose={() => setDrawerOpen(false)}>

--- a/AdminUI/src/pages/WorkflowsPage.tsx
+++ b/AdminUI/src/pages/WorkflowsPage.tsx
@@ -138,11 +138,13 @@ export default function WorkflowsPage() {
                         header: `Name${sortField === 'name' ? (sortDir === 'asc' ? ' ▲' : ' ▼') : ''}`,
                         accessor: (row: typeof data[number]) => row.workflowName,
                         onHeaderClick: () => toggleSort('name'),
+                        ariaSort: sortField === 'name' ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none',
                     },
                     {
                         header: `Version${sortField === 'version' ? (sortDir === 'asc' ? ' ▲' : ' ▼') : ''}`,
                         accessor: (row: typeof data[number]) => row.version ?? 1,
                         onHeaderClick: () => toggleSort('version'),
+                        ariaSort: sortField === 'version' ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none',
                     },
                     {
                         header: 'Steps',


### PR DESCRIPTION
## Summary
- add optional ariaSort support and keyboard navigation to DataTable
- show empty state when no data
- use skip link and main id in Layout
- close Drawer with overlay and escape key
- autofocus first element in Modal
- make Toast screen-reader friendly
- improve DataBrowser loading skeleton and button label
- indicate sorted columns in Workflows page
- label avatar element

## Testing
- `dotnet format TheBackend.sln` *(failed: Restore operation failed)*
- `dotnet build TheBackend.sln -c Release` *(failed: A task was canceled)*
- `dotnet test TheBackend.sln` *(failed: Restore canceled)*

------
https://chatgpt.com/codex/tasks/task_e_6887ffacd734832493dd450706567f69