### PR TITLE
Use theme table on models page

### DIFF
--- a/AdminUI/src/components/ui/table/index.tsx
+++ b/AdminUI/src/components/ui/table/index.tsx
@@ -1,0 +1,64 @@
+import { ReactNode } from "react";
+
+// Props for Table
+interface TableProps {
+  children: ReactNode; // Table content (thead, tbody, etc.)
+  className?: string; // Optional className for styling
+}
+
+// Props for TableHeader
+interface TableHeaderProps {
+  children: ReactNode; // Header row(s)
+  className?: string; // Optional className for styling
+}
+
+// Props for TableBody
+interface TableBodyProps {
+  children: ReactNode; // Body row(s)
+  className?: string; // Optional className for styling
+}
+
+// Props for TableRow
+interface TableRowProps {
+  children: ReactNode; // Cells (th or td)
+  className?: string; // Optional className for styling
+}
+
+// Props for TableCell
+interface TableCellProps {
+  children: ReactNode; // Cell content
+  isHeader?: boolean; // If true, renders as <th>, otherwise <td>
+  className?: string; // Optional className for styling
+}
+
+// Table Component
+const Table: React.FC<TableProps> = ({ children, className }) => {
+  return <table className={`min-w-full  ${className}`}>{children}</table>;
+};
+
+// TableHeader Component
+const TableHeader: React.FC<TableHeaderProps> = ({ children, className }) => {
+  return <thead className={className}>{children}</thead>;
+};
+
+// TableBody Component
+const TableBody: React.FC<TableBodyProps> = ({ children, className }) => {
+  return <tbody className={className}>{children}</tbody>;
+};
+
+// TableRow Component
+const TableRow: React.FC<TableRowProps> = ({ children, className }) => {
+  return <tr className={className}>{children}</tr>;
+};
+
+// TableCell Component
+const TableCell: React.FC<TableCellProps> = ({
+  children,
+  isHeader = false,
+  className,
+}) => {
+  const CellTag = isHeader ? "th" : "td";
+  return <CellTag className={` ${className}`}>{children}</CellTag>;
+};
+
+export { Table, TableHeader, TableBody, TableRow, TableCell };

--- a/AdminUI/src/pages/ModelsPage.tsx
+++ b/AdminUI/src/pages/ModelsPage.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { getModels } from '../services/models';
 import { Button } from '../components/common/Button';
 import type { ModelDefinition } from '../types/models';
-import { DataTable } from '../components/DataTable';
+import { Table, TableBody, TableCell, TableHeader, TableRow } from '../components/ui/table';
 import Skeleton from '../components/common/Skeleton';
 import { Breadcrumb } from '../components/Breadcrumb';
 
@@ -66,29 +66,6 @@ export default function ModelsPage() {
         return (a.properties.length - b.properties.length) * dir;
     });
 
-    const columns = [
-        {
-            header: `Name${sortField === 'name' ? (sortDir === 'asc' ? ' ▲' : ' ▼') : ''}`,
-            accessor: (row: ModelDefinition) => row.modelName,
-            onHeaderClick: () => toggleSort('name'),
-            ariaSort: sortField === 'name' ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none',
-        },
-        {
-            header: `Fields${sortField === 'fields' ? (sortDir === 'asc' ? ' ▲' : ' ▼') : ''}`,
-            accessor: (row: ModelDefinition) => row.properties.length,
-            onHeaderClick: () => toggleSort('fields'),
-            ariaSort: sortField === 'fields' ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none',
-        },
-        {
-            header: 'Actions',
-            accessor: (row: ModelDefinition) => (
-                <Button size="sm" onClick={() => navigate(`/models/${row.modelName}`)} title="Edit model">
-                    Edit
-                </Button>
-            ),
-        },
-    ];
-
     const totalPages = Math.ceil(sorted.length / pageSize);
     const pageData = sorted.slice((page - 1) * pageSize, page * pageSize);
 
@@ -106,7 +83,63 @@ export default function ModelsPage() {
                     </Button>
                 </div>
             </div>
-            <DataTable columns={columns} data={pageData} page={page} pageSize={pageSize} onPageChange={setPage} />
+            <div className="overflow-hidden rounded border border-indigo-200">
+                <div className="max-w-full overflow-x-auto">
+                    <Table>
+                        <TableHeader className="bg-indigo-600 text-white">
+                            <TableRow>
+                                <TableCell
+                                    isHeader
+                                    onClick={() => toggleSort('name')}
+                                    aria-sort={sortField === 'name' ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
+                                    className="p-2 text-left text-xs uppercase cursor-pointer"
+                                >
+                                    Name{sortField === 'name' ? (sortDir === 'asc' ? ' ▲' : ' ▼') : ''}
+                                </TableCell>
+                                <TableCell
+                                    isHeader
+                                    onClick={() => toggleSort('fields')}
+                                    aria-sort={sortField === 'fields' ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
+                                    className="p-2 text-left text-xs uppercase cursor-pointer"
+                                >
+                                    Fields{sortField === 'fields' ? (sortDir === 'asc' ? ' ▲' : ' ▼') : ''}
+                                </TableCell>
+                                <TableCell isHeader className="p-2 text-left text-xs uppercase">
+                                    Actions
+                                </TableCell>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {pageData.length === 0 ? (
+                                <TableRow>
+                                    <TableCell className="p-2" colSpan={3}>
+                                        No data available
+                                    </TableCell>
+                                </TableRow>
+                            ) : (
+                                pageData.map(m => (
+                                    <TableRow
+                                        key={m.modelName}
+                                        className="odd:bg-white even:bg-gray-50 hover:bg-indigo-50"
+                                    >
+                                        <TableCell className="p-2">{m.modelName}</TableCell>
+                                        <TableCell className="p-2">{m.properties.length}</TableCell>
+                                        <TableCell className="p-2">
+                                            <Button
+                                                size="sm"
+                                                onClick={() => navigate(`/models/${m.modelName}`)}
+                                                title="Edit model"
+                                            >
+                                                Edit
+                                            </Button>
+                                        </TableCell>
+                                    </TableRow>
+                                ))
+                            )}
+                        </TableBody>
+                    </Table>
+                </div>
+            </div>
             {totalPages > 1 && (
                 <div className="flex justify-end gap-2">
                     <Button size="sm" onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1}>


### PR DESCRIPTION
## Summary
- add table component in AdminUI using theme code
- show models using the new table instead of DataTable

## Testing
- `dotnet format TheBackend.sln`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`

------
https://chatgpt.com/codex/tasks/task_e_68894a0534788324a3cb2e0d24a2413c