### PR TITLE
Add drag-and-drop workflow editor

### DIFF
--- a/AdminUI/package-lock.json
+++ b/AdminUI/package-lock.json
@@ -8,12 +8,18 @@
       "name": "vite-react-typescript-starter",
       "version": "0.0.0",
       "dependencies": {
+        "@codemirror/autocomplete": "^6.8.0",
+        "@codemirror/lang-javascript": "^6.1.4",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.0",
         "@hookform/resolvers": "^3.3.5",
         "@mui/icons-material": "^5.15.0",
         "@mui/material": "^5.15.0",
         "@tanstack/react-query": "^5.29.5",
+        "@uiw/react-codemirror": "^4.24.2",
         "autoprefixer": "^10.4.19",
         "axios": "^1.10.0",
         "clsx": "^2.1.1",
@@ -350,6 +356,167 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.18.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.18.6.tgz",
+      "integrity": "sha512-PHHBXFomUs5DF+9tCOM/UoW6XQ4R44lLNNhRaW9PKPTU0D7lIjRg3ElxaJnTwsl/oHiR93WSXDBrekhoUGCPtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.8.1.tgz",
+      "integrity": "sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.4.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.4.tgz",
+      "integrity": "sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.2.tgz",
+      "integrity": "sha512-p44TsNArL4IVXDTbapUmEkAlvWs2CFQbcfc0ymDsis1kH2wh0gcY96AS29c/vp2d0y2Tquk1EDSaawpzilUiAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.1.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.8.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.5.tgz",
+      "integrity": "sha512-s3n3KisH7dx3vsoeGMxsbRAgKe4O1vbrnKBClm99PU0fWxmxsx5rR2PfqQgIt+2MMJBHbiJ5rfIdLYfB9NNvsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.11.tgz",
+      "integrity": "sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
+      "integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.38.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.1.tgz",
+      "integrity": "sha512-RmTOkE7hRU3OVREqFVITWHz6ocgBjv08GoePscAakgVQfciA3SGCEk7mb9IzwW61cKKmlTpHXG6DUE5Ubx+MGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.5.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -1222,6 +1389,47 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz",
+      "integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
+      "integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.1.tgz",
+      "integrity": "sha512-ATOImjeVJuvgm3JQ/bpo2Tmv55HSScE2MTPnKRMRIPx2cLhHGyX2VnqpHhtIV1tVzIjZDbcWQm+NCTF40ggZVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.2.tgz",
+      "integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
     },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "5.18.0",
@@ -3285,6 +3493,59 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@uiw/codemirror-extensions-basic-setup": {
+      "version": "4.24.2",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.24.2.tgz",
+      "integrity": "sha512-wW/gjLRvVUeYyhdh2TApn25cvdcR+Rhg6R/j3eTOvXQzU1HNzNYCVH4YKVIfgtfdM/Xs+N8fkk+rbr1YvBppCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@codemirror/autocomplete": ">=6.0.0",
+        "@codemirror/commands": ">=6.0.0",
+        "@codemirror/language": ">=6.0.0",
+        "@codemirror/lint": ">=6.0.0",
+        "@codemirror/search": ">=6.0.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0"
+      }
+    },
+    "node_modules/@uiw/react-codemirror": {
+      "version": "4.24.2",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.24.2.tgz",
+      "integrity": "sha512-kp7DhTq4RR+M2zJBQBrHn1dIkBrtOskcwJX4vVsKGByReOvfMrhqRkGTxYMRDTX6x75EG2mvBJPDKYcUQcHWBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.6",
+        "@codemirror/commands": "^6.1.0",
+        "@codemirror/state": "^6.1.1",
+        "@codemirror/theme-one-dark": "^6.0.0",
+        "@uiw/codemirror-extensions-basic-setup": "4.24.2",
+        "codemirror": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.11.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/theme-one-dark": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0",
+        "codemirror": ">=6.0.0",
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -3598,6 +3859,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3677,6 +3953,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5826,6 +6108,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
+      "integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
+      "license": "MIT"
+    },
     "node_modules/stylis": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
@@ -5983,7 +6271,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -6203,6 +6490,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/AdminUI/package.json
+++ b/AdminUI/package.json
@@ -25,6 +25,12 @@
     "react-hook-form": "^7.51.5",
     "react-router-dom": "^7.7.0",
     "reactflow": "^11.11.4",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
+    "@uiw/react-codemirror": "^4.24.2",
+    "@codemirror/lang-javascript": "^6.1.4",
+    "@codemirror/autocomplete": "^6.8.0",
     "tailwindcss": "^4.0.8",
     "zod": "^3.22.4",
     "zustand": "^5.0.6"

--- a/AdminUI/src/components/WorkflowEditor/ExpressionEditor.tsx
+++ b/AdminUI/src/components/WorkflowEditor/ExpressionEditor.tsx
@@ -1,0 +1,34 @@
+import CodeMirror from '@uiw/react-codemirror';
+import { EditorView } from '@codemirror/view';
+import { javascript } from '@codemirror/lang-javascript';
+import { autocompletion, type CompletionContext, completeFromList } from '@codemirror/autocomplete';
+
+interface Props {
+    value: string;
+    onChange: (value: string) => void;
+    completions?: string[];
+}
+
+export default function ExpressionEditor({ value, onChange, completions = [] }: Props) {
+    const completion = autocompletion({
+        override: [
+            (ctx: CompletionContext) => {
+                const word = ctx.matchBefore(/\w*/);
+                if (!word || word.from == word.to && !ctx.explicit) return null;
+                return {
+                    from: word.from,
+                    options: completions.map(c => ({ label: c, type: 'variable' })),
+                };
+            },
+        ],
+    });
+
+    return (
+        <CodeMirror
+            value={value}
+            height="auto"
+            onChange={(val) => onChange(val)}
+            extensions={[javascript(), EditorView.lineWrapping, completion]}
+        />
+    );
+}

--- a/AdminUI/src/components/WorkflowEditor/GlobalVariablesEditor.tsx
+++ b/AdminUI/src/components/WorkflowEditor/GlobalVariablesEditor.tsx
@@ -1,0 +1,69 @@
+import type { WorkflowDefinition, Parameter } from '../../types/models';
+import { valueTypes } from '../../types/models';
+import { Button } from '../common/Button';
+
+interface Props {
+    workflow: WorkflowDefinition;
+    onChange: (wf: WorkflowDefinition) => void;
+}
+
+export default function GlobalVariablesEditor({ workflow, onChange }: Props) {
+    const update = (index: number, partial: Partial<Parameter>) => {
+        const vars = [...workflow.globalVariables];
+        vars[index] = { ...vars[index], ...partial } as Parameter;
+        onChange({ ...workflow, globalVariables: vars });
+    };
+
+    const add = () => {
+        onChange({
+            ...workflow,
+            globalVariables: [...workflow.globalVariables, { key: '', value: '', valueType: 'string' }],
+        });
+    };
+
+    const remove = (index: number) => {
+        onChange({
+            ...workflow,
+            globalVariables: workflow.globalVariables.filter((_, i) => i !== index),
+        });
+    };
+
+    return (
+        <div className="space-y-2 mb-4">
+            <h3 className="font-semibold">Global Variables</h3>
+            {workflow.globalVariables.map((v, idx) => (
+                <div key={idx} className="grid grid-cols-4 gap-2 items-end">
+                    <input
+                        className="border rounded p-2 dark:bg-neutral-800"
+                        placeholder="Key"
+                        value={v.key}
+                        onChange={(e) => update(idx, { key: e.target.value })}
+                    />
+                    <select
+                        className="border rounded p-2 dark:bg-neutral-800"
+                        value={v.valueType}
+                        onChange={(e) => update(idx, { valueType: e.target.value as any })}
+                    >
+                        {valueTypes.map((t) => (
+                            <option key={t} value={t}>
+                                {t}
+                            </option>
+                        ))}
+                    </select>
+                    <input
+                        className="border rounded p-2 dark:bg-neutral-800"
+                        placeholder="Value"
+                        value={v.value}
+                        onChange={(e) => update(idx, { value: e.target.value })}
+                    />
+                    <Button variant="danger" onClick={() => remove(idx)}>
+                        Delete
+                    </Button>
+                </div>
+            ))}
+            <Button variant="secondary" onClick={add}>
+                Add Variable
+            </Button>
+        </div>
+    );
+}

--- a/AdminUI/src/components/WorkflowEditor/StepList.tsx
+++ b/AdminUI/src/components/WorkflowEditor/StepList.tsx
@@ -1,0 +1,78 @@
+import { DndContext, closestCenter, PointerSensor, useSensor, useSensors, DragEndEvent } from '@dnd-kit/core';
+import { SortableContext, useSortable, arrayMove, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import type { WorkflowStep } from '../../types/models';
+import { Button } from '../common/Button';
+
+interface Props {
+    steps: WorkflowStep[];
+    selectedIndex: number | null;
+    onSelect: (index: number | null) => void;
+    onReorder: (steps: WorkflowStep[]) => void;
+    onAdd: () => void;
+}
+
+export default function StepList({ steps, selectedIndex, onSelect, onReorder, onAdd }: Props) {
+    const sensors = useSensors(useSensor(PointerSensor));
+
+    const handleDragEnd = (event: DragEndEvent) => {
+        const { active, over } = event;
+        if (over && active.id !== over.id) {
+            const oldIndex = Number(active.id);
+            const newIndex = Number(over.id);
+            onReorder(arrayMove(steps, oldIndex, newIndex));
+        }
+    };
+
+    return (
+        <div className="space-y-2">
+            <h3 className="font-bold text-lg mb-2">Steps</h3>
+            <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+                <SortableContext items={steps.map((_, idx) => idx.toString())} strategy={verticalListSortingStrategy}>
+                    {steps.map((step, idx) => (
+                        <SortableStepItem
+                            key={idx}
+                            id={idx.toString()}
+                            index={idx}
+                            step={step}
+                            selected={idx === selectedIndex}
+                            onSelect={() => onSelect(idx)}
+                        />
+                    ))}
+                </SortableContext>
+            </DndContext>
+            <Button variant="secondary" onClick={onAdd}>
+                Add Step
+            </Button>
+        </div>
+    );
+}
+
+interface ItemProps {
+    id: string;
+    index: number;
+    step: WorkflowStep;
+    selected: boolean;
+    onSelect: () => void;
+}
+
+function SortableStepItem({ id, index, step, selected, onSelect }: ItemProps) {
+    const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id });
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+    };
+
+    return (
+        <div
+            ref={setNodeRef}
+            style={style}
+            {...attributes}
+            {...listeners}
+            className={`border rounded p-2 cursor-pointer ${selected ? 'bg-brand-50 border-brand-500' : ''}`}
+            onClick={onSelect}
+        >
+            Step {index + 1}: {step.type}
+        </div>
+    );
+}

--- a/AdminUI/src/components/WorkflowEditor/StepParameterEditor.tsx
+++ b/AdminUI/src/components/WorkflowEditor/StepParameterEditor.tsx
@@ -1,0 +1,70 @@
+import type { WorkflowStep, Parameter } from '../../types/models';
+import { valueTypes } from '../../types/models';
+import { Button } from '../common/Button';
+import ExpressionEditor from './ExpressionEditor';
+
+interface Props {
+    step: WorkflowStep;
+    onChange: (step: WorkflowStep) => void;
+    completions: string[];
+}
+
+export default function StepParameterEditor({ step, onChange, completions }: Props) {
+    const update = (idx: number, partial: Partial<Parameter>) => {
+        const list = [...step.parameters];
+        list[idx] = { ...list[idx], ...partial } as Parameter;
+        onChange({ ...step, parameters: list });
+    };
+
+    const add = () => {
+        onChange({
+            ...step,
+            parameters: [...step.parameters, { key: '', value: '', valueType: 'string' }],
+        });
+    };
+
+    const remove = (idx: number) => {
+        onChange({
+            ...step,
+            parameters: step.parameters.filter((_, i) => i !== idx),
+        });
+    };
+
+    return (
+        <div className="space-y-2">
+            <h4 className="font-medium">Parameters</h4>
+            {step.parameters.map((p, idx) => (
+                <div key={idx} className="grid grid-cols-4 gap-2 items-start">
+                    <input
+                        className="border rounded p-2 dark:bg-neutral-800"
+                        placeholder="Key"
+                        value={p.key}
+                        onChange={(e) => update(idx, { key: e.target.value })}
+                    />
+                    <select
+                        className="border rounded p-2 dark:bg-neutral-800"
+                        value={p.valueType}
+                        onChange={(e) => update(idx, { valueType: e.target.value as any })}
+                    >
+                        {valueTypes.map((v) => (
+                            <option key={v} value={v}>
+                                {v}
+                            </option>
+                        ))}
+                    </select>
+                    <ExpressionEditor
+                        value={p.value}
+                        onChange={(val) => update(idx, { value: val })}
+                        completions={completions}
+                    />
+                    <Button variant="danger" onClick={() => remove(idx)}>
+                        Delete
+                    </Button>
+                </div>
+            ))}
+            <Button variant="secondary" onClick={add}>
+                Add Parameter
+            </Button>
+        </div>
+    );
+}

--- a/AdminUI/src/components/WorkflowEditor/StepPropertiesPanel.tsx
+++ b/AdminUI/src/components/WorkflowEditor/StepPropertiesPanel.tsx
@@ -1,0 +1,77 @@
+import type { WorkflowStep, Parameter } from '../../types/models';
+import { stepTypes } from '../../types/models';
+import StepParameterEditor from './StepParameterEditor';
+import ExpressionEditor from './ExpressionEditor';
+
+const defaultParams: Record<string, Parameter[]> = {
+    CreateEntity: [
+        { key: 'ModelName', valueType: 'string', value: '' },
+        { key: 'Mappings', valueType: 'json', value: '[]' },
+    ],
+    UpdateEntity: [
+        { key: 'ModelName', valueType: 'string', value: '' },
+        { key: 'Id', valueType: 'string', value: '' },
+        { key: 'Mappings', valueType: 'json', value: '[]' },
+    ],
+    QueryEntity: [
+        { key: 'ModelName', valueType: 'string', value: '' },
+        { key: 'Filter', valueType: 'string', value: '' },
+    ],
+    SendEmail: [
+        { key: 'To', valueType: 'string', value: '' },
+        { key: 'Subject', valueType: 'string', value: '' },
+        { key: 'Body', valueType: 'string', value: '' },
+    ],
+};
+
+interface Props {
+    step: WorkflowStep;
+    index: number;
+    onChange: (step: WorkflowStep) => void;
+    availableCompletions: string[];
+}
+
+export default function StepPropertiesPanel({ step, onChange, availableCompletions }: Props) {
+    const update = (partial: Partial<WorkflowStep>) => {
+        let next = { ...step, ...partial } as WorkflowStep;
+        if (partial.type && partial.type !== step.type) {
+            next = { ...next, parameters: JSON.parse(JSON.stringify(defaultParams[partial.type] || [])) };
+        }
+        onChange(next);
+    };
+
+    return (
+        <div className="space-y-3">
+            <h3 className="text-lg font-semibold">Step {step.type}</h3>
+            <select
+                className="border rounded p-2 w-full dark:bg-neutral-800"
+                value={step.type}
+                onChange={(e) => update({ type: e.target.value })}
+            >
+                {stepTypes.map((t) => (
+                    <option key={t} value={t}>
+                        {t}
+                    </option>
+                ))}
+            </select>
+            <ExpressionEditor
+                value={step.condition ?? ''}
+                onChange={(val) => update({ condition: val })}
+                completions={availableCompletions}
+            />
+            <input
+                className="border rounded p-2 w-full dark:bg-neutral-800"
+                placeholder="OnError (e.g. Retry:3)"
+                value={step.onError ?? ''}
+                onChange={(e) => update({ onError: e.target.value })}
+            />
+            <input
+                className="border rounded p-2 w-full dark:bg-neutral-800"
+                placeholder="Output Variable"
+                value={step.outputVariable ?? ''}
+                onChange={(e) => update({ outputVariable: e.target.value })}
+            />
+            <StepParameterEditor step={step} onChange={onChange} completions={availableCompletions} />
+        </div>
+    );
+}

--- a/AdminUI/src/components/WorkflowEditor/WorkflowEditor.tsx
+++ b/AdminUI/src/components/WorkflowEditor/WorkflowEditor.tsx
@@ -1,0 +1,67 @@
+import StepList from './StepList';
+import StepPropertiesPanel from './StepPropertiesPanel';
+import GlobalVariablesEditor from './GlobalVariablesEditor';
+import WorkflowFlowchart from './WorkflowFlowchart';
+import type { WorkflowDefinition, WorkflowStep } from '../../types/models';
+
+interface Props {
+    workflow: WorkflowDefinition;
+    onChange: (workflow: WorkflowDefinition) => void;
+    selectedStepIndex: number | null;
+    setSelectedStepIndex: (index: number | null) => void;
+}
+
+export default function WorkflowEditor({
+    workflow,
+    onChange,
+    selectedStepIndex,
+    setSelectedStepIndex,
+}: Props) {
+    const updateSteps = (steps: WorkflowStep[]) => {
+        onChange({ ...workflow, steps });
+    };
+
+    const addStep = () => {
+        updateSteps([
+            ...workflow.steps,
+            { type: 'CreateEntity', parameters: [], condition: '', onError: '', outputVariable: '' },
+        ]);
+        setSelectedStepIndex(workflow.steps.length);
+    };
+
+    const completions = [
+        ...workflow.globalVariables.map((g) => `Vars.${g.key}`),
+        ...workflow.steps.map((s) => s.outputVariable ? `Workflow.${s.outputVariable}` : '').filter(Boolean),
+        'Input.',
+    ];
+
+    return (
+        <div className="grid grid-cols-12 gap-4 h-full">
+            <div className="col-span-3 border-r pr-4 overflow-y-auto">
+                <GlobalVariablesEditor workflow={workflow} onChange={onChange} />
+                <StepList
+                    steps={workflow.steps}
+                    selectedIndex={selectedStepIndex}
+                    onSelect={setSelectedStepIndex}
+                    onReorder={updateSteps}
+                    onAdd={addStep}
+                />
+            </div>
+            <div className="col-span-9 pl-4 space-y-4">
+                <WorkflowFlowchart workflow={workflow} onSelect={setSelectedStepIndex} />
+                {selectedStepIndex !== null && workflow.steps[selectedStepIndex] && (
+                    <StepPropertiesPanel
+                        step={workflow.steps[selectedStepIndex]}
+                        index={selectedStepIndex}
+                        onChange={(step) => {
+                            const steps = [...workflow.steps];
+                            steps[selectedStepIndex] = step;
+                            updateSteps(steps);
+                        }}
+                        availableCompletions={completions}
+                    />
+                )}
+            </div>
+        </div>
+    );
+}

--- a/AdminUI/src/components/WorkflowEditor/WorkflowFlowchart.tsx
+++ b/AdminUI/src/components/WorkflowEditor/WorkflowFlowchart.tsx
@@ -1,0 +1,35 @@
+import ReactFlow, { Background, Controls, Node, Edge } from 'reactflow';
+import 'reactflow/dist/style.css';
+import type { WorkflowDefinition } from '../../types/models';
+
+interface Props {
+    workflow: WorkflowDefinition;
+    onSelect?: (index: number) => void;
+}
+
+export default function WorkflowFlowchart({ workflow, onSelect }: Props) {
+    const nodes: Node[] = workflow.steps.map((s, idx) => ({
+        id: idx.toString(),
+        data: { label: `${idx + 1}. ${s.type}` },
+        position: { x: idx * 200, y: 0 },
+    }));
+    const edges: Edge[] = workflow.steps.slice(1).map((_, idx) => ({
+        id: `e${idx}-${idx + 1}`,
+        source: idx.toString(),
+        target: (idx + 1).toString(),
+    }));
+
+    return (
+        <div style={{ height: 200 }} className="border rounded">
+            <ReactFlow
+                nodes={nodes}
+                edges={edges}
+                fitView
+                onNodeClick={(_, node) => onSelect && onSelect(Number(node.id))}
+            >
+                <Background />
+                <Controls />
+            </ReactFlow>
+        </div>
+    );
+}

--- a/AdminUI/src/pages/WorkflowsPage.tsx
+++ b/AdminUI/src/pages/WorkflowsPage.tsx
@@ -10,13 +10,35 @@ import type { WorkflowDefinition, ModelDefinition } from '../types/models';
 import { stepTypes, workflowEvents } from '../types/models';
 import Toast from '../components/Toast';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import WorkflowEditorForm, { defaultParams } from '../components/WorkflowEditorForm';
+import WorkflowEditor from '../components/WorkflowEditor/WorkflowEditor';
+import type { Parameter } from '../types/models';
 import Skeleton from '../components/common/Skeleton';
 import { Modal } from '../components/Modal';
 import { Button } from '../components/common/Button';
 import Input from '../components/common/Input';
 import { Breadcrumb } from '../components/Breadcrumb';
 import { Table, TableBody, TableCell, TableHeader, TableRow } from '../components/common/Table';
+
+const defaultParams: Record<string, Parameter[]> = {
+  CreateEntity: [
+    { key: 'ModelName', valueType: 'string', value: '' },
+    { key: 'Mappings', valueType: 'json', value: '[]' },
+  ],
+  UpdateEntity: [
+    { key: 'ModelName', valueType: 'string', value: '' },
+    { key: 'Id', valueType: 'string', value: '' },
+    { key: 'Mappings', valueType: 'json', value: '[]' },
+  ],
+  QueryEntity: [
+    { key: 'ModelName', valueType: 'string', value: '' },
+    { key: 'Filter', valueType: 'string', value: '' },
+  ],
+  SendEmail: [
+    { key: 'To', valueType: 'string', value: '' },
+    { key: 'Subject', valueType: 'string', value: '' },
+    { key: 'Body', valueType: 'string', value: '' },
+  ],
+};
 
 export default function WorkflowsPage() {
   const queryClient = useQueryClient();
@@ -40,6 +62,7 @@ export default function WorkflowsPage() {
   const [newModalOpen, setNewModalOpen] = useState(false);
   const [confirmRollback, setConfirmRollback] = useState<{ name: string; version: number } | null>(null);
   const [page, setPage] = useState(1);
+  const [selectedStepIndex, setSelectedStepIndex] = useState<number | null>(null);
   const [selectedModel, setSelectedModel] = useState('');
   const [selectedEvent, setSelectedEvent] = useState<typeof workflowEvents[number]>(workflowEvents[0]);
   const pageSize = 10;
@@ -70,6 +93,7 @@ export default function WorkflowsPage() {
     };
     setOriginal(def);
     setEditing(def);
+    setSelectedStepIndex(0);
   };
 
   const openEditor = async (name: string | null) => {
@@ -77,6 +101,7 @@ export default function WorkflowsPage() {
     const wf = await getWorkflow(name);
     setOriginal(wf);
     setEditing(JSON.parse(JSON.stringify(wf)));
+    setSelectedStepIndex(0);
   };
 
   const save = async (def: WorkflowDefinition) => {
@@ -203,7 +228,12 @@ export default function WorkflowsPage() {
             {hasChanges && (
               <p className="text-sm text-orange-600">You have unsaved changes.</p>
             )}
-            <WorkflowEditorForm workflow={editing} onChange={setEditing} />
+            <WorkflowEditor
+              workflow={editing}
+              onChange={setEditing}
+              selectedStepIndex={selectedStepIndex}
+              setSelectedStepIndex={setSelectedStepIndex}
+            />
             <div className="flex justify-end space-x-2">
               <Button variant="outline" onClick={reset}>Reset</Button>
               <Button variant="outline" onClick={cancelEdit}>Cancel</Button>


### PR DESCRIPTION
## Summary
- implement new WorkflowEditor components
- enable drag-and-drop reordering via dnd-kit
- add CodeMirror-based expression editor with autocomplete
- render workflow preview using ReactFlow
- update workflows page to use the new editor

## Testing
- `dotnet format TheBackend.sln --verbosity minimal`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`


------
https://chatgpt.com/codex/tasks/task_e_688a4f92952c8324a0b4c371b6f306c8