### PR TITLE
Add drag-and-drop workflow editor

### DIFF
--- a/AdminUI/package-lock.json
+++ b/AdminUI/package-lock.json
@@ -8,6 +8,8 @@
       "name": "vite-react-typescript-starter",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.0",
         "@hookform/resolvers": "^3.3.5",
@@ -350,6 +352,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -2990,6 +3045,7 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -5983,7 +6039,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {

--- a/AdminUI/package.json
+++ b/AdminUI/package.json
@@ -25,6 +25,8 @@
     "react-hook-form": "^7.51.5",
     "react-router-dom": "^7.7.0",
     "reactflow": "^11.11.4",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "tailwindcss": "^4.0.8",
     "zod": "^3.22.4",
     "zustand": "^5.0.6"

--- a/AdminUI/src/components/WorkflowEditor/GlobalVariablesEditor.tsx
+++ b/AdminUI/src/components/WorkflowEditor/GlobalVariablesEditor.tsx
@@ -1,0 +1,67 @@
+import type { WorkflowDefinition, Parameter } from '../../types/models';
+import { valueTypes } from '../../types/models';
+import { Button } from '../common/Button';
+
+interface Props {
+    workflow: WorkflowDefinition;
+    onChange: (workflow: WorkflowDefinition) => void;
+}
+
+export default function GlobalVariablesEditor({ workflow, onChange }: Props) {
+    const updateVar = (i: number, partial: Partial<Parameter>) => {
+        const list = [...workflow.globalVariables];
+        list[i] = { ...list[i], ...partial } as Parameter;
+        onChange({ ...workflow, globalVariables: list });
+    };
+
+    const addVar = () => {
+        onChange({
+            ...workflow,
+            globalVariables: [...workflow.globalVariables, { key: '', value: '', valueType: 'string' }],
+        });
+    };
+
+    const removeVar = (i: number) => {
+        const list = workflow.globalVariables.filter((_, idx) => idx !== i);
+        onChange({ ...workflow, globalVariables: list });
+    };
+
+    return (
+        <div className="space-y-2 mb-4">
+            <h3 className="font-semibold">Global Variables</h3>
+            {workflow.globalVariables.map((p, idx) => (
+                <div key={idx} className="grid grid-cols-4 gap-2 items-end">
+                    <input
+                        className="border rounded p-2 w-full dark:bg-neutral-800"
+                        placeholder="Key"
+                        value={p.key}
+                        onChange={(e) => updateVar(idx, { key: e.target.value })}
+                    />
+                    <select
+                        className="border rounded p-2 w-full dark:bg-neutral-800"
+                        value={p.valueType}
+                        onChange={(e) => updateVar(idx, { valueType: e.target.value as any })}
+                    >
+                        {valueTypes.map((v) => (
+                            <option key={v} value={v}>
+                                {v}
+                            </option>
+                        ))}
+                    </select>
+                    <input
+                        className="border rounded p-2 w-full dark:bg-neutral-800"
+                        placeholder="Value"
+                        value={p.value}
+                        onChange={(e) => updateVar(idx, { value: e.target.value })}
+                    />
+                    <Button variant="danger" onClick={() => removeVar(idx)}>
+                        Delete
+                    </Button>
+                </div>
+            ))}
+            <Button variant="secondary" onClick={addVar}>
+                Add Variable
+            </Button>
+        </div>
+    );
+}

--- a/AdminUI/src/components/WorkflowEditor/StepItem.tsx
+++ b/AdminUI/src/components/WorkflowEditor/StepItem.tsx
@@ -1,0 +1,30 @@
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import type { WorkflowStep } from '../../types/models';
+
+interface Props {
+    id: string;
+    step: WorkflowStep;
+    selected: boolean;
+    onClick: () => void;
+}
+
+export default function StepItem({ id, step, selected, onClick }: Props) {
+    const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+    };
+    return (
+        <div
+            ref={setNodeRef}
+            style={style}
+            {...attributes}
+            {...listeners}
+            onClick={onClick}
+            className={`border rounded p-2 cursor-pointer bg-white dark:bg-neutral-800 ${selected ? 'bg-brand-50 dark:bg-brand-500/20 border-brand-500' : ''} ${isDragging ? 'opacity-50' : ''}`}
+        >
+            Step {parseInt(id) + 1}: {step.type}
+        </div>
+    );
+}

--- a/AdminUI/src/components/WorkflowEditor/StepList.tsx
+++ b/AdminUI/src/components/WorkflowEditor/StepList.tsx
@@ -1,0 +1,63 @@
+import { DndContext, PointerSensor, useSensor, useSensors, closestCenter, DragEndEvent } from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
+import type { WorkflowStep } from '../../types/models';
+import { stepTypes } from '../../types/models';
+import StepItem from './StepItem';
+import { Button } from '../common/Button';
+
+interface Props {
+    steps: WorkflowStep[];
+    selectedIndex: number | null;
+    onSelect: (index: number | null) => void;
+    onChange: (steps: WorkflowStep[]) => void;
+}
+
+export default function StepList({ steps, selectedIndex, onSelect, onChange }: Props) {
+    const sensors = useSensors(useSensor(PointerSensor));
+
+    const handleDragEnd = (event: DragEndEvent) => {
+        const { active, over } = event;
+        if (over && active.id !== over.id) {
+            const oldIndex = parseInt(active.id as string, 10);
+            const newIndex = parseInt(over.id as string, 10);
+            const newSteps = arrayMove(steps, oldIndex, newIndex);
+            onChange(newSteps);
+            onSelect(newIndex);
+        }
+    };
+
+    const addStep = () => {
+        const newStep: WorkflowStep = {
+            type: stepTypes[0],
+            parameters: [],
+            condition: '',
+            onError: '',
+            outputVariable: '',
+        };
+        const newSteps = [...steps, newStep];
+        onChange(newSteps);
+        onSelect(newSteps.length - 1);
+    };
+
+    return (
+        <div className="space-y-2">
+            <h3 className="font-bold text-lg mb-2">Steps</h3>
+            <DndContext collisionDetection={closestCenter} sensors={sensors} onDragEnd={handleDragEnd}>
+                <SortableContext items={steps.map((_, idx) => idx.toString())} strategy={verticalListSortingStrategy}>
+                    {steps.map((step, idx) => (
+                        <StepItem
+                            key={idx}
+                            id={idx.toString()}
+                            step={step}
+                            selected={idx === selectedIndex}
+                            onClick={() => onSelect(idx)}
+                        />
+                    ))}
+                </SortableContext>
+            </DndContext>
+            <Button variant="secondary" onClick={addStep}>
+                Add Step
+            </Button>
+        </div>
+    );
+}

--- a/AdminUI/src/components/WorkflowEditor/StepParameterEditor.tsx
+++ b/AdminUI/src/components/WorkflowEditor/StepParameterEditor.tsx
@@ -1,0 +1,67 @@
+import type { Parameter, WorkflowStep } from '../../types/models';
+import { valueTypes } from '../../types/models';
+import { Button } from '../common/Button';
+
+interface Props {
+    step: WorkflowStep;
+    onChange: (updatedStep: WorkflowStep) => void;
+}
+
+export default function StepParameterEditor({ step, onChange }: Props) {
+    const updateParam = (i: number, partial: Partial<Parameter>) => {
+        const newParams = [...(step.parameters ?? [])];
+        newParams[i] = { ...newParams[i], ...partial } as Parameter;
+        onChange({ ...step, parameters: newParams });
+    };
+
+    const addParam = () => {
+        onChange({
+            ...step,
+            parameters: [...(step.parameters ?? []), { key: '', value: '', valueType: 'string' }],
+        });
+    };
+
+    const removeParam = (i: number) => {
+        const newParams = (step.parameters ?? []).filter((_, idx) => idx !== i);
+        onChange({ ...step, parameters: newParams });
+    };
+
+    return (
+        <div className="space-y-2">
+            <h4 className="font-medium">Parameters</h4>
+            {(step.parameters ?? []).map((p, idx) => (
+                <div key={idx} className="grid grid-cols-4 gap-2 items-end">
+                    <input
+                        className="border rounded p-2 dark:bg-neutral-800"
+                        placeholder="Key"
+                        value={p.key}
+                        onChange={(e) => updateParam(idx, { key: e.target.value })}
+                    />
+                    <select
+                        className="border rounded p-2 dark:bg-neutral-800"
+                        value={p.valueType}
+                        onChange={(e) => updateParam(idx, { valueType: e.target.value as any })}
+                    >
+                        {valueTypes.map((v) => (
+                            <option key={v} value={v}>
+                                {v}
+                            </option>
+                        ))}
+                    </select>
+                    <input
+                        className="border rounded p-2 dark:bg-neutral-800"
+                        placeholder="Value"
+                        value={p.value}
+                        onChange={(e) => updateParam(idx, { value: e.target.value })}
+                    />
+                    <Button variant="danger" onClick={() => removeParam(idx)}>
+                        Delete
+                    </Button>
+                </div>
+            ))}
+            <Button variant="secondary" onClick={addParam}>
+                Add Parameter
+            </Button>
+        </div>
+    );
+}

--- a/AdminUI/src/components/WorkflowEditor/StepPropertiesPanel.tsx
+++ b/AdminUI/src/components/WorkflowEditor/StepPropertiesPanel.tsx
@@ -1,0 +1,49 @@
+import StepParameterEditor from './StepParameterEditor';
+import type { WorkflowStep } from '../../types/models';
+import { stepTypes } from '../../types/models';
+
+interface Props {
+    step: WorkflowStep;
+    index: number;
+    onChange: (updatedStep: WorkflowStep) => void;
+}
+
+export default function StepPropertiesPanel({ step, onChange }: Props) {
+    const update = (partial: Partial<WorkflowStep>) => onChange({ ...step, ...partial });
+
+    return (
+        <div className="space-y-3">
+            <h3 className="text-lg font-semibold">Step Details</h3>
+            <select
+                className="border rounded p-2 w-full dark:bg-neutral-800"
+                value={step.type}
+                onChange={(e) => update({ type: e.target.value })}
+            >
+                {stepTypes.map((t) => (
+                    <option key={t} value={t}>
+                        {t}
+                    </option>
+                ))}
+            </select>
+            <input
+                className="border rounded p-2 w-full dark:bg-neutral-800"
+                placeholder="Condition (C# expression)"
+                value={step.condition ?? ''}
+                onChange={(e) => update({ condition: e.target.value })}
+            />
+            <input
+                className="border rounded p-2 w-full dark:bg-neutral-800"
+                placeholder="OnError (e.g. Retry:3)"
+                value={step.onError ?? ''}
+                onChange={(e) => update({ onError: e.target.value })}
+            />
+            <input
+                className="border rounded p-2 w-full dark:bg-neutral-800"
+                placeholder="Output Variable"
+                value={step.outputVariable ?? ''}
+                onChange={(e) => update({ outputVariable: e.target.value })}
+            />
+            <StepParameterEditor step={step} onChange={onChange} />
+        </div>
+    );
+}

--- a/AdminUI/src/components/WorkflowEditor/WorkflowEditor.tsx
+++ b/AdminUI/src/components/WorkflowEditor/WorkflowEditor.tsx
@@ -1,0 +1,45 @@
+import StepList from './StepList';
+import StepPropertiesPanel from './StepPropertiesPanel';
+import GlobalVariablesEditor from './GlobalVariablesEditor';
+import type { WorkflowDefinition } from '../../types/models';
+
+interface Props {
+    workflow: WorkflowDefinition;
+    onChange: (workflow: WorkflowDefinition) => void;
+    selectedStepIndex: number | null;
+    setSelectedStepIndex: (index: number | null) => void;
+}
+
+export default function WorkflowEditor({
+    workflow,
+    onChange,
+    selectedStepIndex,
+    setSelectedStepIndex,
+}: Props) {
+    return (
+        <div className="grid grid-cols-12 gap-4 h-full">
+            <div className="col-span-3 border-r pr-4 overflow-y-auto">
+                <GlobalVariablesEditor workflow={workflow} onChange={onChange} />
+                <StepList
+                    steps={workflow.steps}
+                    selectedIndex={selectedStepIndex}
+                    onSelect={setSelectedStepIndex}
+                    onChange={(steps) => onChange({ ...workflow, steps })}
+                />
+            </div>
+            <div className="col-span-9 pl-4">
+                {selectedStepIndex !== null && selectedStepIndex < workflow.steps.length && (
+                    <StepPropertiesPanel
+                        step={workflow.steps[selectedStepIndex]}
+                        index={selectedStepIndex}
+                        onChange={(updatedStep) => {
+                            const steps = [...workflow.steps];
+                            steps[selectedStepIndex] = updatedStep;
+                            onChange({ ...workflow, steps });
+                        }}
+                    />
+                )}
+            </div>
+        </div>
+    );
+}

--- a/AdminUI/src/pages/WorkflowsPage.tsx
+++ b/AdminUI/src/pages/WorkflowsPage.tsx
@@ -10,7 +10,8 @@ import type { WorkflowDefinition, ModelDefinition } from '../types/models';
 import { stepTypes, workflowEvents } from '../types/models';
 import Toast from '../components/Toast';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import WorkflowEditorForm, { defaultParams } from '../components/WorkflowEditorForm';
+import WorkflowEditor from '../components/WorkflowEditor/WorkflowEditor';
+import { defaultParams } from '../components/WorkflowEditorForm';
 import Skeleton from '../components/common/Skeleton';
 import { Modal } from '../components/Modal';
 import { Button } from '../components/common/Button';
@@ -40,6 +41,7 @@ export default function WorkflowsPage() {
   const [newModalOpen, setNewModalOpen] = useState(false);
   const [confirmRollback, setConfirmRollback] = useState<{ name: string; version: number } | null>(null);
   const [page, setPage] = useState(1);
+  const [selectedStepIndex, setSelectedStepIndex] = useState<number | null>(null);
   const [selectedModel, setSelectedModel] = useState('');
   const [selectedEvent, setSelectedEvent] = useState<typeof workflowEvents[number]>(workflowEvents[0]);
   const pageSize = 10;
@@ -70,6 +72,7 @@ export default function WorkflowsPage() {
     };
     setOriginal(def);
     setEditing(def);
+    setSelectedStepIndex(0);
   };
 
   const openEditor = async (name: string | null) => {
@@ -77,17 +80,20 @@ export default function WorkflowsPage() {
     const wf = await getWorkflow(name);
     setOriginal(wf);
     setEditing(JSON.parse(JSON.stringify(wf)));
+    setSelectedStepIndex(0);
   };
 
   const save = async (def: WorkflowDefinition) => {
     await saveMutation.mutateAsync(def);
     setEditing(null);
+    setSelectedStepIndex(null);
   };
 
   const hasChanges = editing && original && JSON.stringify(editing) !== JSON.stringify(original);
   const cancelEdit = () => {
     if (hasChanges && !confirm('Discard unsaved changes?')) return;
     setEditing(null);
+    setSelectedStepIndex(null);
   };
   const reset = () => {
     if (original) setEditing(JSON.parse(JSON.stringify(original)));
@@ -203,7 +209,12 @@ export default function WorkflowsPage() {
             {hasChanges && (
               <p className="text-sm text-orange-600">You have unsaved changes.</p>
             )}
-            <WorkflowEditorForm workflow={editing} onChange={setEditing} />
+            <WorkflowEditor
+              workflow={editing}
+              onChange={setEditing}
+              selectedStepIndex={selectedStepIndex}
+              setSelectedStepIndex={setSelectedStepIndex}
+            />
             <div className="flex justify-end space-x-2">
               <Button variant="outline" onClick={reset}>Reset</Button>
               <Button variant="outline" onClick={cancelEdit}>Cancel</Button>


### PR DESCRIPTION
## Summary
- introduce modular WorkflowEditor components
- add StepList with drag-and-drop using dnd-kit
- support editing step details and parameters
- manage global variables separately
- integrate WorkflowEditor into WorkflowsPage
- add @dnd-kit packages

## Testing
- `dotnet format TheBackend.sln`
- `dotnet build TheBackend.sln -c Release`
- `dotnet test TheBackend.sln`

------
https://chatgpt.com/codex/tasks/task_e_688a4f92952c8324a0b4c371b6f306c8